### PR TITLE
fixed docstrings

### DIFF
--- a/scikit_tt/data_driven/regression.py
+++ b/scikit_tt/data_driven/regression.py
@@ -5,36 +5,39 @@ import sys
 import numpy as np
 import scipy.linalg as lin
 import scikit_tt.data_driven.transform as tdt
+from scikit_tt.tensor_train import TT
 import scikit_tt.utils as utl
 import time as _time
 
+
 def arr(x_data, y_data, basis_list, initial_guess, repeats=1, rcond=10**-2, string='ARR', progress=True):
-    """Alternating ridge regression on transformed data tensors.
+    """
+    Alternating ridge regression on transformed data tensors.
 
     Approximates the solution of a ridge regression in the TT format. For details, see [1]_.
 
     Parameters
     ----------
-    x_data: ndarray
+    x_data : np.ndarray
         snapshot matrix which is transformed
-    y_data: ndarray
+    y_data : np.ndarray
         snapshot matrix for the right-hand side
-    basis_list: list of lists of lambda functions
+    basis_list : list of lists of lambda functions
         list of basis functions in every mode
-    initial_guess: instance of TT class
+    initial_guess : TT
         initial guess for the solution of operator @ x = right_hand_side
-    repeats: int, optional
+    repeats : int, optional
         number of repeats of the ALS, default is 1
-    rcond: float, optional
+    rcond : float, optional
         cut-off ratio for singular values of the subproblems, parameter for NumPy's lstsq, default is 1e-2
-    string: string
+    string : string, optional
         string to show above progress bar
-    progress: boolean, optional
+    progress : boolean, optional
         whether to show progress bar, default is True
 
     Returns
     -------
-    solution: instance of TT class
+    TT
         approximated solution of the regression problem
 
     References
@@ -124,24 +127,25 @@ def arr(x_data, y_data, basis_list, initial_guess, repeats=1, rcond=10**-2, stri
 
 
 def mandy_cm(x, y, phi, threshold=0):
-    """Multidimensional Approximation of Nonlinear Dynamics (MANDy)
+    """
+    Multidimensional Approximation of Nonlinear Dynamics (MANDy).
 
     Coordinate-major approach for construction of the tensor train xi. See [1]_ for details.
 
     Parameters
     ----------
-    x: ndarray
+    x : np.ndarray
         snapshot matrix of size d x m (e.g., coordinates)
-    y: ndarray
+    y : np.ndarray
         corresponding snapshot matrix of size d x m (e.g., derivatives)
-    phi: list of lambda functions
+    phi : list of lambda functions
         list of basis functions
-    threshold: float, optional
+    threshold : float, optional
         threshold for SVDs, default is 0
 
     Returns
     -------
-    xi: instance of TT class
+    TT
         tensor train of coefficients for chosen basis functions
 
     References
@@ -170,26 +174,27 @@ def mandy_cm(x, y, phi, threshold=0):
 
 
 def mandy_fm(x, y, phi, threshold=0, add_one=True):
-    """Multidimensional Approximation of Nonlinear Dynamics (MANDy)
+    """
+    Multidimensional Approximation of Nonlinear Dynamics (MANDy).
 
     Function-major approach for construction of the tensor train xi. See [1]_ for details.
 
     Parameters
     ----------
-    x: ndarray
+    x : np.ndarray
         snapshot matrix of size d x m (e.g., coordinates)
-    y: ndarray
+    y : np.ndarray
         corresponding snapshot matrix of size d x m (e.g., derivatives)
-    phi: list of lambda functions
+    phi : list of lambda functions
         list of basis functions
-    threshold: float, optional
+    threshold : float, optional
         threshold for SVDs, default is 0
-    add_one: bool, optional
+    add_one : bool, optional
         whether to add the basis function 1 to the cores or not, default is True
 
     Returns
     -------
-    xi: instance of TT class
+    TT
         tensor train of coefficients for chosen basis functions
 
     References
@@ -217,24 +222,26 @@ def mandy_fm(x, y, phi, threshold=0, add_one=True):
 
     return xi
 
+
 def mandy_kb(x, y, basis_list):
-    """Kernel-based MANDy.
+    """
+    Kernel-based MANDy.
 
     Kernel-based version of MANDy for solving regression problems on transformed data tensors. See [1]_ and _[2] 
     for details.
 
     Parameters
     ----------
-    x: ndarray
+    x : np.ndarray
         snapshot matrix of size d x m (e.g., coordinates)
-    y: ndarray
+    y : np.ndarray
         corresponding snapshot matrix of size d' x m (e.g., derivatives)
-    basis_list: list of lists of lambda functions
+    basis_list : list of lists of lambda functions
         list of basis functions in every mode
 
     Returns
     -------
-    z: ndarray
+    np.ndarray
         matrix such that the solution of the regression problem can be expressed as z@psi_1^T
 
     References
@@ -258,20 +265,22 @@ def mandy_kb(x, y, basis_list):
 
 # private functions # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
+
 def __arr_construct_stack_left(i, stack_left, x_data, basis_list, solution):
-    """Construct left stack for ARR
+    """
+    Construct left stack for ARR
 
     Parameters
     ----------
-    i: int
+    i : int
         core index
-    stack_left: list of ndarrays
+    stack_left : list of np.ndarray
         left stack
-    x_data: ndarray
+    x_data : np.ndarray
         snapshot matrix which is transformed
-    basis_list: list of lists of lambda functions
+    basis_list : list of lists of lambda functions
         list of basis functions in every mode
-    solution: instance of TT class
+    solution : TT
         approximated solution of the system of linear equations
     """
 
@@ -292,19 +301,20 @@ def __arr_construct_stack_left(i, stack_left, x_data, basis_list, solution):
 
 
 def __arr_construct_stack_right(i, stack_right, x_data, basis_list, solution):
-    """Construct right stack for ARR
+    """
+    Construct right stack for ARR.
 
     Parameters
     ----------
-    i: int
+    i : int
         core index
-    stack_right: list of ndarrays
+    stack_right : list of np.ndarray
         right stack
-    x_data: ndarray
+    x_data : np.ndarray
         snapshot matrix which is transformed
-    basis_list: list of lists of lambda functions
+    basis_list : list of lists of lambda functions
         list of basis functions in every mode
-    solution: instance of TT class
+    solution : TT
         approximated solution of the system of linear equations
     """
 
@@ -325,26 +335,27 @@ def __arr_construct_stack_right(i, stack_right, x_data, basis_list, solution):
 
 
 def __arr_construct_micro_matrix(i, stack_left, stack_right, x_data, basis_list, solution):
-    """Construct micro matrix for ARR
+    """
+    Construct micro matrix for ARR.
 
     Parameters
     ----------
-    i: int
+    i : int
         core index
-    stack_left: list of ndarrays
+    stack_left : list of np.ndarray
         left stack
-    stack_right: list of ndarrays
+    stack_right : list of np.ndarray
         right stack
-    x_data: ndarray
+    x_data : np.ndarray
         snapshot matrix which is transformed
-    basis_list: list of lists of lambda functions
+    basis_list : list of lists of lambda functions
         list of basis functions in every mode
-    solution: instance of TT class
+    solution : TT
         approximated solution of the system of linear equations
 
     Returns
     -------
-    micro_matrix: ndarray
+    np.ndarray
         ith micro matrix
     """
 
@@ -359,22 +370,24 @@ def __arr_construct_micro_matrix(i, stack_left, stack_right, x_data, basis_list,
 
     return micro_matrix
 
+
 def __arr_update_core(i, micro_matrix, rhs, solution, rcond, direction):
-    """Update TT core for ARR
+    """
+    Update TT core for ARR.
 
     Parameters
     ----------
-    i: int
+    i : int
         core index
-    micro_op: ndarray
+    micro_op : np.ndarray
         micro matrix for ith TT core
-    rhs: ndarray
+    rhs : np.ndarray
         right-hand side for ith TT core
-    solution: instance of TT class
+    solution : TT
         approximated solution of the system of linear equations
-    rcond: float
+    rcond : float
         cut-off ratio for singular values of the subproblems, parameter for NumPy's lstsq
-    direction: string
+    direction : string
         'forward' if first half sweep, 'backward' if second half sweep
     """
 

--- a/scikit_tt/data_driven/regression.py
+++ b/scikit_tt/data_driven/regression.py
@@ -22,7 +22,7 @@ def arr(x_data, y_data, basis_list, initial_guess, repeats=1, rcond=10**-2, stri
         snapshot matrix which is transformed
     y_data : np.ndarray
         snapshot matrix for the right-hand side
-    basis_list : list of lists of lambda functions
+    basis_list : list[list[function]]
         list of basis functions in every mode
     initial_guess : TT
         initial guess for the solution of operator @ x = right_hand_side
@@ -138,7 +138,7 @@ def mandy_cm(x, y, phi, threshold=0):
         snapshot matrix of size d x m (e.g., coordinates)
     y : np.ndarray
         corresponding snapshot matrix of size d x m (e.g., derivatives)
-    phi : list of lambda functions
+    phi : list[function]
         list of basis functions
     threshold : float, optional
         threshold for SVDs, default is 0
@@ -185,7 +185,7 @@ def mandy_fm(x, y, phi, threshold=0, add_one=True):
         snapshot matrix of size d x m (e.g., coordinates)
     y : np.ndarray
         corresponding snapshot matrix of size d x m (e.g., derivatives)
-    phi : list of lambda functions
+    phi : list[function]
         list of basis functions
     threshold : float, optional
         threshold for SVDs, default is 0
@@ -236,7 +236,7 @@ def mandy_kb(x, y, basis_list):
         snapshot matrix of size d x m (e.g., coordinates)
     y : np.ndarray
         corresponding snapshot matrix of size d' x m (e.g., derivatives)
-    basis_list : list of lists of lambda functions
+    basis_list : list[list[function]]
         list of basis functions in every mode
 
     Returns
@@ -274,11 +274,11 @@ def __arr_construct_stack_left(i, stack_left, x_data, basis_list, solution):
     ----------
     i : int
         core index
-    stack_left : list of np.ndarray
+    stack_left : list[np.ndarray]
         left stack
     x_data : np.ndarray
         snapshot matrix which is transformed
-    basis_list : list of lists of lambda functions
+    basis_list : list[list[function]]
         list of basis functions in every mode
     solution : TT
         approximated solution of the system of linear equations
@@ -308,11 +308,11 @@ def __arr_construct_stack_right(i, stack_right, x_data, basis_list, solution):
     ----------
     i : int
         core index
-    stack_right : list of np.ndarray
+    stack_right : list[np.ndarray]
         right stack
     x_data : np.ndarray
         snapshot matrix which is transformed
-    basis_list : list of lists of lambda functions
+    basis_list : list[list[function]]
         list of basis functions in every mode
     solution : TT
         approximated solution of the system of linear equations
@@ -342,13 +342,13 @@ def __arr_construct_micro_matrix(i, stack_left, stack_right, x_data, basis_list,
     ----------
     i : int
         core index
-    stack_left : list of np.ndarray
+    stack_left : list[np.ndarray]
         left stack
-    stack_right : list of np.ndarray
+    stack_right : list[np.ndarray]
         right stack
     x_data : np.ndarray
         snapshot matrix which is transformed
-    basis_list : list of lists of lambda functions
+    basis_list : list[list[function]]
         list of basis functions in every mode
     solution : TT
         approximated solution of the system of linear equations

--- a/scikit_tt/data_driven/tdmd.py
+++ b/scikit_tt/data_driven/tdmd.py
@@ -2,31 +2,33 @@
 
 import numpy as np
 import scipy.linalg as lin
+from scikit_tt.tensor_train import TT
 
 
 def tdmd_exact(x, y, threshold=0, ortho_l=True, ortho_r=True):
-    """Exact TDMD
+    """
+    Exact TDMD.
 
     Tensor-based version of exact DMD. See [1]_ for details.
 
     Parameters
     ----------
-    x: instance of TT class
+    x : TT
         tensor train containing the snapshots
-    y: instance of TT class
+    y : TT
         tensor-train containing the shifted snapshots
-    threshold: float, optional
+    threshold : float, optional
         threshold for SVDs, default is 0
-    ortho_l: bool, optional
+    ortho_l : bool, optional
         whether to left-orthonormalize the first TT cores of x, default is True
-    ortho_r: bool, optional
+    ortho_r : bool, optional
         whether to right-orthonormalize the last TT cores of x, default is True
 
     Returns
     -------
-    dmd_eigenvalues: ndarray
+    dmd_eigenvalues : np.ndarray
         vector containing the DMD eigenvalues
-    dmd_modes: instance of TT class
+    dmd_modes : TT
         tensor train containing the DMD modes
 
     References
@@ -59,28 +61,29 @@ def tdmd_exact(x, y, threshold=0, ortho_l=True, ortho_r=True):
 
 
 def tdmd_standard(x, y, threshold=0, ortho_l=True, ortho_r=True):
-    """Standard TDMD
+    """
+    Standard TDMD.
 
     Tensor-based version of standard DMD. See [1]_ for details.
 
     Parameters
     ----------
-    x: instance of TT class
+    x : TT
         tensor train containing the snapshots
-    y: instance of TT class
+    y : TT
         tensor-train containing the shifted snapshots
-    threshold: float, optional
+    threshold : float, optional
         threshold for SVDs, default is 0
-    ortho_l: bool, optional
+    ortho_l : bool, optional
         whether to left-orthonormalize the first TT cores of x, default is True
-    ortho_r: bool, optional
+    ortho_r : bool, optional
         whether to right-orthonormalize the last TT cores of x, default is True
 
     Returns
     -------
-    dmd_eigenvalues: ndarray
+    dmd_eigenvalues : np.ndarray
         vector containing the DMD eigenvalues
-    dmd_modes: instance of TT class
+    dmd_modes : TT
         tensor train containing the DMD modes
 
     References
@@ -112,18 +115,19 @@ def tdmd_standard(x, y, threshold=0, ortho_l=True, ortho_r=True):
 
 
 def __tdmd_reduced_matrix(x, y):
-    """Compute the reduced matrix for finding DMD eigenvalues. See [1]_ for details.
+    """
+    Compute the reduced matrix for finding DMD eigenvalues. See [1]_ for details.
 
     Parameters
     ----------
-    x: instance of TT class
+    x : TT
         tensor train containing the snapshots
-    y: instance of TT class
+    y : TT
         tensor-train containing the shifted snapshots
 
     Returns
     -------
-    reduced_matrix: ndarray
+    np.ndarray
         reduced matrix
 
     References

--- a/scikit_tt/data_driven/tedmd.py
+++ b/scikit_tt/data_driven/tedmd.py
@@ -17,11 +17,11 @@ def amuset_hosvd(data_matrix, x_indices, y_indices, basis_list, threshold=1e-2, 
     ----------
     data_matrix : np.ndarray
         snapshot matrix
-    x_indices : np.ndarray or list of np.ndarray
+    x_indices : np.ndarray or list[np.ndarray]
         index sets for snapshot matrix x
-    y_indices : np.ndarray or list of np.ndarray
+    y_indices : np.ndarray or list[np.ndarray]
         index sets for snapshot matrix y
-    basis_list : list of lists of lambda functions
+    basis_list : list[list[function]]
         list of basis functions in every mode
     threshold : float, optional
         threshold for SVD/HOSVD, default is 1e-2
@@ -30,9 +30,9 @@ def amuset_hosvd(data_matrix, x_indices, y_indices, basis_list, threshold=1e-2, 
 
     Returns
     -------
-    eigenvalues : np.ndarray or list of np.ndarray
+    eigenvalues : np.ndarray or list[np.ndarray]
         tEDMD eigenvalues
-    eigentensors : TT or list of TT
+    eigentensors : TT or list[TT]
         tEDMD eigentensors in TT format
 
     References
@@ -97,11 +97,11 @@ def amuset_hocur(data_matrix, x_indices, y_indices, basis_list, max_rank=1000, m
     ----------
     data_matrix : np.ndarray
         snapshot matrix
-    x_indices : np.ndarray or list of np.ndarray
+    x_indices : np.ndarray or list[np.ndarray]
         index sets for snapshot matrix x
-    y_indices : np.ndarray or list of np.ndarray
+    y_indices : np.ndarray or list[np.ndarray]
         index sets for snapshot matrix y
-    basis_list : list of lists of lambda functions
+    basis_list : list[list[function]]
         list of basis functions in every mode
     max_rank : int, optional
         maximum ranks for HOSVD as well as HOCUR, default is 1000
@@ -112,9 +112,9 @@ def amuset_hocur(data_matrix, x_indices, y_indices, basis_list, max_rank=1000, m
 
     Returns
     -------
-    eigenvalues : np.ndarray or list of np.ndarray
+    eigenvalues : np.ndarray or list[np.ndarray]
         tEDMD eigenvalues
-    eigentensors : TT or list of TT
+    eigentensors : TT or list[TT]
         tEDMD eigentensors in TT format
 
     References

--- a/scikit_tt/data_driven/tedmd.py
+++ b/scikit_tt/data_driven/tedmd.py
@@ -3,34 +3,36 @@
 import scikit_tt.data_driven.transform as tdt
 import numpy as np
 from scipy import linalg
+from scikit_tt.tensor_train import TT
 
 
 def amuset_hosvd(data_matrix, x_indices, y_indices, basis_list, threshold=1e-2, progress=False):
-    """AMUSEt (AMUSE on tensors) using HOSVD.
+    """
+    AMUSEt (AMUSE on tensors) using HOSVD.
 
     Apply tEDMD to a given data matrix by using AMUSEt with HOSVD. This procedure is a tensor-based
     version of AMUSE using the tensor-train format. For more details, see [1]_.
 
     Parameters
     ----------
-    data_matrix: ndarray
+    data_matrix : np.ndarray
         snapshot matrix
-    x_indices: ndarray or list of ndarrays
+    x_indices : np.ndarray or list of np.ndarray
         index sets for snapshot matrix x
-    y_indices: ndarray or list of ndarrays
+    y_indices : np.ndarray or list of np.ndarray
         index sets for snapshot matrix y
-    basis_list: list of lists of lambda functions
+    basis_list : list of lists of lambda functions
         list of basis functions in every mode
-    threshold: float, optional
+    threshold : float, optional
         threshold for SVD/HOSVD, default is 1e-2
-    progress: boolean, optional
+    progress : boolean, optional
         whether to show progress bar, default is False
 
     Returns
     -------
-    eigenvalues: ndarray or list of ndarrays
+    eigenvalues : np.ndarray or list of np.ndarray
         tEDMD eigenvalues
-    eigentensors: instance of TT class or list of instances of TT class
+    eigentensors : TT or list of TT
         tEDMD eigentensors in TT format
 
     References
@@ -85,33 +87,34 @@ def amuset_hosvd(data_matrix, x_indices, y_indices, basis_list, threshold=1e-2, 
 
 
 def amuset_hocur(data_matrix, x_indices, y_indices, basis_list, max_rank=1000, multiplier=2, progress=False):
-    """AMUSEt (AMUSE on tensors) using HOCUR.
+    """
+    AMUSEt (AMUSE on tensors) using HOCUR.
 
     Apply tEDMD to a given data matrix by using AMUSEt with HOCUR. This procedure is a tensor-based
     version of AMUSE using the tensor-train format. For more details, see [1]_.
 
     Parameters
     ----------
-    data_matrix: ndarray
+    data_matrix : np.ndarray
         snapshot matrix
-    x_indices: ndarray or list of ndarrays
+    x_indices : np.ndarray or list of np.ndarray
         index sets for snapshot matrix x
-    y_indices: ndarray or list of ndarrays
+    y_indices : np.ndarray or list of np.ndarray
         index sets for snapshot matrix y
-    basis_list: list of lists of lambda functions
+    basis_list : list of lists of lambda functions
         list of basis functions in every mode
-    max_rank: int, optional
+    max_rank : int, optional
         maximum ranks for HOSVD as well as HOCUR, default is 1000
-    multiplier: int
+    multiplier : int
         multiplier for HOCUR
-    progress: boolean, optional
+    progress : boolean, optional
         whether to show progress bar, default is False
 
     Returns
     -------
-    eigenvalues: ndarray or list of ndarrays
+    eigenvalues : np.ndarray or list of np.ndarray
         tEDMD eigenvalues
-    eigentensors: instance of TT class or list of instances of TT class
+    eigentensors : TT or list of TT
         tEDMD eigentensors in TT format
 
     References
@@ -166,28 +169,29 @@ def amuset_hocur(data_matrix, x_indices, y_indices, basis_list, max_rank=1000, m
 
 
 def _reduced_matrix(last_core, x_indices, y_indices, threshold=1e-3):
-    """Compute reduced matrix for AMUSEt.
+    """
+    Compute reduced matrix for AMUSEt.
 
     Parameters
     ----------
-    last_core: ndarray
+    last_core : np.ndarray
         last TT core of left-orthonormalized psi_z
-    x_indices: ndarray
+    x_indices : np.ndarray
         index set for snapshot matrix x
-    y_indices: ndarray
+    y_indices : np.ndarray
         index set for snapshot matrix y
-    threshold: float, optional
+    threshold : float, optional
         threshold for SVD, default is 1e-4
 
     Returns
     -------
-    matrix: ndarray
+    matrix : np.ndarray
         reduced matrix
-    u: ndarray
+    u : np.ndarray
         left-orthonormal matrix of the SVD of the last core of psi_x
-    s: ndarray
+    s : np.ndarray
         vector of singular values of the SVD of the last core of psi_x
-    v: ndarray
+    v : np.ndarray
         right-orthonormal matrix of the SVD of the last core of psi_x
     """
 

--- a/scikit_tt/data_driven/transform.py
+++ b/scikit_tt/data_driven/transform.py
@@ -192,16 +192,16 @@ def basis_decomposition(x, phi, single_core=None):
 
     Parameters
     ----------
-    x: ndarray
+    x: np.ndarray
         snapshot matrix of size d x m
-    phi: list of lists of lambda functions
+    phi: list[list[function]]
         list of basis functions in every mode
     single_core: None or int, optional
         return only the ith core of psi if single_core=i (<p), default is None
 
     Returns
     -------
-    psi: instance of TT class or ndarray
+    psi: instance of TT class or np.ndarray
         tensor train of basis function evaluations if single_core=None, 4-dimensional array if single core
         is an integer
 
@@ -286,9 +286,9 @@ def coordinate_major(x, phi, single_core=None):
 
     Parameters
     ----------
-    x: ndarray
+    x: np.ndarray
         snapshot matrix of size d x m
-    phi: list of lambda functions
+    phi: list[function]
         list of basis functions
     single_core: None or int, optional
         return only the ith core of psi if single_core=i (<p), default is None
@@ -377,9 +377,9 @@ def function_major(x, phi, add_one=True, single_core=None):
 
     Parameters
     ----------
-    x: ndarray
+    x : np.np.ndarray
         snapshot matrix of size d x m
-    phi: list of lambda functions
+    phi : list[function]
         list of basis functions
     add_one: bool, optional
         whether to add the basis function 1 to the cores or not, default is True
@@ -472,16 +472,16 @@ def gram(x_1, x_2, basis_list):
 
     Parameters
     ----------
-    x_1: ndarray
+    x_1: np.ndarray
         data matrix for psi_1
-    x_2: ndarray
+    x_2: np.ndarray
         data matrix for psi_2
-    basis_list: list of lists of lambda functions
+    basis_list: list[list[function]]
         list of basis functions in every mode
 
     Returns
     -------
-    gram: ndarray
+    gram: np.ndarray
         Gram matrix
 
     References
@@ -508,11 +508,11 @@ def hocur(x, basis_list, ranks, repeats=1, multiplier=10, progress=True, string=
 
     Parameters
     ----------
-    x: ndarray
+    x: np.ndarray
         data matrix
-    basis_list: list of lists of lambda functions
+    basis_list: list[list[function]]
         list of basis functions in every mode
-    ranks: list of ints or int
+    ranks: list[int] or int
         maximum TT ranks of the resulting TT representation; if type is int, then the ranks are set to
         [1, ranks, ..., ranks, 1]; note that - depending on the number of linearly independent rows/columns that have
         been found - the TT ranks may be reduced during the decomposition
@@ -676,9 +676,9 @@ def __hocur_first_col_inds(dimensions, ranks, multiplier):
 
     Parameters
     ----------
-    dimensions: list of ints
+    dimensions: list[int]
         dimensions of a given tensor
-    ranks: list of ints
+    ranks: list[int]
         ranks for decomposition
     multiplier: int
         multiply the number of initially chosen column indices (given by ranks) in order to increase the probability of
@@ -686,7 +686,7 @@ def __hocur_first_col_inds(dimensions, ranks, multiplier):
 
     Returns
     -------
-    col_inds: list of lists of ints
+    col_inds: list[list[int]]
         array containing single indices
     """
 
@@ -717,18 +717,18 @@ def __hocur_extract_matrix(data, basis_list, row_coordinates_list, col_coordinat
 
     Parameters
     ----------
-    data: ndarray
+    data: np.ndarray
         data matrix
-    basis_list: list of lists of lambda functions
+    basis_list: list[list[function]]
         list of basis functions in every mode
-    row_coordinates_list: list of lists of ints
+    row_coordinates_list: list[list[int]]
         list of row indices
-    col_coordinates_list: list of lists of ints
+    col_coordinates_list: list[list[int]]
         list of column indices
 
     Returns
     -------
-    matrix: ndarray
+    matrix: np.ndarray
         extracted matrix
     """
 
@@ -846,12 +846,12 @@ def __hocur_find_li_cols(matrix, tol=1e-14):
 
     Parameters
     ----------
-    matrix: ndarray (m,n)
+    matrix: np.ndarray (m,n)
         rectangular matrix
 
     Returns
     -------
-    cols: list of ints
+    cols: list[int]
         indices of linearly independent columns
     """
 
@@ -878,7 +878,7 @@ def __hocur_maxvolume(matrix, maximum_iterations=1000, tolerance=1e-5):
 
     Parameters
     ----------
-    matrix: ndarray (n,r)
+    matrix: np.ndarray (n,r)
         rectangular matrix with rank r
     maximum_iterations: int
         maximum number of iterations, default is 100
@@ -887,7 +887,7 @@ def __hocur_maxvolume(matrix, maximum_iterations=1000, tolerance=1e-5):
 
     Returns
     -------
-    rows: list of ints
+    rows: list[int]
         rows of the matrix which build the dominant submatrix
 
     References

--- a/scikit_tt/data_driven/ulam.py
+++ b/scikit_tt/data_driven/ulam.py
@@ -8,24 +8,25 @@ from scikit_tt.tensor_train import TT
 
 
 def ulam_2d(transitions, states, simulations):
-    """TT approximation of the Perron-Frobenius operator in 2D
+    """
+    TT approximation of the Perron-Frobenius operator in 2D.
 
     Given transitions of particles in a 2-dimensional potential, compute the approximation of the corresponding Perron-
     Frobenius operator in TT format. See [1]_ for details.
 
     Parameters
     ----------
-    transitions: ndarray
+    transitions : np.ndarray
         matrix containing the transitions, each row is of the form [x_1, x_2, y_1, y_2] representing a transition from
         state (x_1, x_2) to (y_1, y_2)
-    states: list of ints
+    states : list of int
         number of states in x- and y-direction
-    simulations: int
+    simulations : int
         number of simulations per state
 
     Returns
     -------
-    operator: instance of TT class
+    TT
         TT approximation of the Perron-Frobenius operator
 
      References
@@ -55,24 +56,25 @@ def ulam_2d(transitions, states, simulations):
 
 
 def ulam_3d(transitions, states, simulations):
-    """TT approximation of the Perron-Frobenius operator in 3D
+    """
+    TT approximation of the Perron-Frobenius operator in 3D.
 
     Given transitions of particles in a 3-dimensional potential, compute the approximation of the corresponding Perron-
     Frobenius operator in TT format. See [1]_ for details.
 
     Parameters
     ----------
-    transitions: ndarray
+    transitions : np.ndarray
         matrix containing the transitions, each row is of the form [x_1, x_2, x_3, y_1, y_2, y_3] representing a
         transition from state (x_1, x_2, x_3) to (y_1, y_2, y_3)
-    states: list of ints
+    states : list of int
         number of states in x-, y-, and z-direction
-    simulations: int
+    simulations : int
         number of simulations per state
 
     Returns
     -------
-    operator: instance of TT class
+    TT
         TT approximation of the Perron-Frobenius operator
 
      References

--- a/scikit_tt/data_driven/ulam.py
+++ b/scikit_tt/data_driven/ulam.py
@@ -19,7 +19,7 @@ def ulam_2d(transitions, states, simulations):
     transitions : np.ndarray
         matrix containing the transitions, each row is of the form [x_1, x_2, y_1, y_2] representing a transition from
         state (x_1, x_2) to (y_1, y_2)
-    states : list of int
+    states : list[int]
         number of states in x- and y-direction
     simulations : int
         number of simulations per state
@@ -67,7 +67,7 @@ def ulam_3d(transitions, states, simulations):
     transitions : np.ndarray
         matrix containing the transitions, each row is of the form [x_1, x_2, x_3, y_1, y_2, y_3] representing a
         transition from state (x_1, x_2, x_3) to (y_1, y_2, y_3)
-    states : list of int
+    states : list[int]
         number of states in x-, y-, and z-direction
     simulations : int
         number of simulations per state

--- a/scikit_tt/models.py
+++ b/scikit_tt/models.py
@@ -5,22 +5,24 @@ import numpy as np
 from scikit_tt.tensor_train import TT
 import scikit_tt.slim as slim
 
+
 def cantor_dust(dimension, level):
-    """Construction of a (multidimensional) Cantor dust
+    """
+    Construction of a (multidimensional) Cantor dust.
 
     Generate a binary tensor representing a Cantor dust, see [1]_, by exploiting the
     tensor-train format and Kronecker products.
 
     Parameters
     ----------
-    dimension: int
+    dimension : int
         dimension of the Cantor dust
-    level: int
+    level : int
         level of the fractal construction to generate
 
     Returns
     -------
-    fractal: ndarray
+    np.ndarray
         tensor representing the Cantor dust
 
     References
@@ -47,25 +49,25 @@ def cantor_dust(dimension, level):
 
 
 def co_oxidation(order, k_ad_co, cyclic=True):
-    """"CO oxidation on RuO2
+    """
+    CO oxidation on RuO2.
 
     Model for the CO oxidation on a RuO2 surface. For a detailed description of the process and the construction of the
     corresponding TT operator, we refer to [1]_,[2]_, and [3]_.
 
     Arguments
     ---------
-    order: int
+    order : int
         number of reaction sites (= order of the operator)
-    k_ad_co: float
+    k_ad_co : float
         reaction rate constant for the adsorption of CO
-    cyclic: bool, optional
+    cyclic : bool, optional
         whether model should be cyclic or not, default=True
 
     Returns
     -------
-    operator: instance of TT class
+    TT
         TT operator of the process
-
 
     References
     ----------
@@ -104,17 +106,18 @@ def co_oxidation(order, k_ad_co, cyclic=True):
 
 
 def fpu_coefficients(d):
-    """Construction of the exact coefficient tensor for the application of MANDy to the Fermi-Pasta-Ulam problem using
+    """
+    Construction of the exact coefficient tensor for the application of MANDy to the Fermi-Pasta-Ulam problem using
     the basis set {1, x, x^2, x^3}. See [1]_ for details.
 
     Parameters
     ----------
-    d: int
+    d : int
         number of oscillators
 
     Returns
     -------
-    coefficient_tensor: instance of TT class
+    TT
         exact coefficient tensor
 
     References
@@ -175,19 +178,20 @@ def fpu_coefficients(d):
 
 
 def kuramoto_coefficients(d, w):
-    """Construction of the exact coefficient tensor for the application of MANDy to the Kuramoto model using the basis
+    """
+    Construction of the exact coefficient tensor for the application of MANDy to the Kuramoto model using the basis
     set {1, x, x^2, x^3}. See [1]_ for details.
 
     Parameters
     ----------
-    d: int
+    d : int
         number of oscillators
-    w: ndarray
+    w : np.ndarray
         natural frequencies
 
     Returns
     -------
-    coefficient_tensor: instance of TT class
+    TT
         exact coefficient tensor
 
     References
@@ -216,7 +220,8 @@ def kuramoto_coefficients(d, w):
 
 
 def multisponge(dimension, level):
-    """Construction of a multisponge
+    """
+    Construction of a multisponge.
 
     Generate a binary tensor representing a multisponge fractal (e.g., Sierpinski carpet,
     Menger sponge, etc.), see [1]_, by exploiting the tensor-train format and Kronecker
@@ -224,14 +229,14 @@ def multisponge(dimension, level):
 
     Parameters
     ----------
-    dimension: int (>1)
-        dimension of the multisponge
-    level: int
+    dimension : int
+        dimension (>1) of the multisponge
+    level : int
         level of the fractal construction to generate
 
     Returns
     -------
-    fractal: ndarray
+    np.ndarray
         tensor representing the multisponge fractal
 
     References
@@ -271,25 +276,26 @@ def multisponge(dimension, level):
 
 
 def rgb_fractal(matrix_r, matrix_g, matrix_b, level):
-    """Construction of an RGB fractal
+    """
+    Construction of an RGB fractal.
 
     Generate a 3-dimensional tensor representing an RGB fractal, see [1]_, by exploiting
     the tensor-train format.
 
     Parameters
     ----------
-    matrix_r: ndarray
+    matrix_r : np.ndarray
         matrix representing red primaries
-    matrix_g: ndarray
+    matrix_g : np.ndarray
         matrix representing green primaries
-    matrix_b: ndarray
+    matrix_b : np.ndarray
         matrix representing blue primaries
-    level: int
+    level : int
         level of the fractal construction to generate
 
     Returns
     -------
-    fractal: ndarray
+    np.ndarray
         tensor representing the RGB fractal
 
     References
@@ -321,21 +327,21 @@ def rgb_fractal(matrix_r, matrix_g, matrix_b, level):
 
 
 def signaling_cascade(d):
-    """Signaling cascade
+    """
+    Signaling cascade.
 
     Model for a cascading process on a genetic network consisting of genes of species S_1 , ..., S_d. For a detailed
     description of the process and the construction of the corresponding TT operator, we refer to [1]_.
 
     Arguments
     ---------
-    d: int
+    d : int
         number of species (= order of the operator)
 
     Returns
     -------
-    operator: instance of TT class
+    TT
         TT operator of the model
-
 
     References
     ----------
@@ -351,7 +357,7 @@ def signaling_cascade(d):
 
     # make operator stochastic
     s_mat_0[-1, -1] = -0.07 * 63
-    m_mat [-1, -1] = 0
+    m_mat[-1, -1] = 0
 
     # define TT cores
     cores = [np.zeros([1, 64, 64, 3])]
@@ -377,20 +383,20 @@ def signaling_cascade(d):
 
 
 def toll_station(number_of_lanes, number_of_cars):
-    """"Toll station
+    """"
+    Toll station.
 
-    Model for a quasi-realistic traffic problem
+    Model for a quasi-realistic traffic problem.
 
     Arguments
     ---------
-    number_of_lanes:
-    number_of_cars:
+    number_of_lanes : int
+    number_of_cars : int
 
     Returns
     -------
-    operator: instance of TT class
+    TT
         TT operator of the process
-
 
     References
     ----------
@@ -441,27 +447,27 @@ def toll_station(number_of_lanes, number_of_cars):
 
 
 def two_step_destruction(k_1, k_2, k_3, m):
-    """"Two-step destruction
+    """"
+    Two-step destruction.
 
     Model for a two-step mechanism for the destruction of molecules. For a detailed description of the process and the
     construction of the corresponding TT operator, we refer to [1]_.
 
     Arguments
     ---------
-    k_1: float
+    k_1 : float
         rate constant for the first reaction
-    k_2: float
+    k_2 : float
         rate constant for the second reaction
-    k_3: float
+    k_3 : float
         rate constant for the third reaction
-    m: int
+    m : int
         exponent determining the maximum number of molecules
 
     Returns
     -------
-    operator: instance of TT class
+    TT
         TT operator of the process
-
 
     References
     ----------
@@ -502,21 +508,22 @@ def two_step_destruction(k_1, k_2, k_3, m):
 
 
 def vicsek_fractal(dimension, level):
-    """Construction of a Vicsek fractal
+    """
+    Construction of a Vicsek fractal.
 
     Generate a binary tensor representing a Vicsek fractal, see [1]_, by exploiting the
     tensor-train format and Kronecker products.
 
     Parameters
     ----------
-    dimension: int (>1)
-        dimension of the Vicsek fractal
-    level: int
+    dimension : int
+        dimension (>1) of the Vicsek fractal
+    level : int
         level of the fractal construction to generate
 
     Returns
     -------
-    fractal: ndarray
+    np.ndarray
         tensor representing the Vicsek fractal
 
     References

--- a/scikit_tt/slim.py
+++ b/scikit_tt/slim.py
@@ -7,7 +7,8 @@ from scikit_tt.tensor_train import TT
 
 
 def slim_mme(state_space, single_cell_reactions, two_cell_reactions, threshold=0):
-    """SLIM decomposition for Markov generators
+    """
+    SLIM decomposition for Markov generators.
 
     Construct a tensor-train decomposition of a Markov generator representing a nearest-neighbor interaction system
     (NNIS) described by a list of single-cell and two-cell reactions. Note that the implementation of the SLIM algorithm
@@ -16,21 +17,21 @@ def slim_mme(state_space, single_cell_reactions, two_cell_reactions, threshold=0
 
     Parameters
     ----------
-    state_space: list of ints
+    state_space : list of int
         number of states of each cell in the NNIS
-    single_cell_reactions: list of lists of lists of ints and floats
+    single_cell_reactions : list of lists of lists of ints and floats
         list of considered single-cell reactions, i.e. single_cell_reactions[i][j] is a list of the form
         [reactant_state, product_state, reactions_rate] describing the jth reaction on the ith cell.
-    two_cell_reactions: list of lists of lists of ints and floats
+    two_cell_reactions : list of lists of lists of ints and floats
         list of considered two-cell reactions, i.e. two_cell_reactions[i][j] is a list of the form
         [reactant_state_i, product_state_i, reactant_state_i+1, product_state_i+1, reactions_rate] describing the jth
         reaction between the ith and the (i+1)th cell.
-    threshold: float, optional
+    threshold : float, optional
         threshold for the singular value decomposition of the two-cell reaction cores, default is 1e-14
 
     Returns
     -------
-    operator: instance of TT class
+    TT
         TT representation of the Markov generator of the NNIS
 
     References
@@ -172,30 +173,31 @@ def slim_mme(state_space, single_cell_reactions, two_cell_reactions, threshold=0
 
 
 def slim_mme_hom(state_space, single_cell_reactions, two_cell_reactions, cyclic=True, threshold=0):
-    """Homogeneous SLIM decomposition for Markov generators
+    """
+    Homogeneous SLIM decomposition for Markov generators.
 
     Construct a tensor-train decomposition of a Markov generator representing a homogeneous nearest-neighbor interaction
     system. See [1]_ and [2]_ for details.
 
     Parameters
     ----------
-    state_space: list of ints
+    state_space : list of int
         number of states of each cell in the NNIS
-    single_cell_reactions: list of lists of ints and floats
+    single_cell_reactions : list of lists of ints and floats
         list of considered single-cell reactions, i.e. single_cell_reactions[i] is a list of the form
         [reactant_state, product_state, reactions_rate] describing the ith reaction on each cell.
-    two_cell_reactions: list of lists of ints and floats
+    two_cell_reactions : list of lists of ints and floats
         list of considered two-cell reactions, i.e. two_cell_reactions[i] is a list of the form
         [reactant_state_i, product_state_i, reactant_state_i+1, product_state_i+1, reactions_rate] describing the ith
         reaction between neighboring cells
-    cyclic: bool, optional
+    cyclic : bool, optional
         whether the system is cyclic or not, default is True
-    threshold: float, optional
+    threshold : float, optional
         threshold for the singular value decomposition of the two-cell reaction core, default is 1e-14
 
     Returns
     -------
-    operator: instance of TT class
+    TT
         TT representation of the Markov generator of the NNIS
 
     References
@@ -220,24 +222,25 @@ def slim_mme_hom(state_space, single_cell_reactions, two_cell_reactions, cyclic=
 
 
 def __slim_tcr_decomposition(super_core, threshold):
-    """Two-cell reaction decomposition
+    """
+    Two-cell reaction decomposition.
 
     Decompose a super-core representing the interactions between two cells.
 
     Parameters
     ----------
-    super_core: ndarray
+    super_core : np.ndarray
         tensor with order 4
-    threshold: float
+    threshold : float
             threshold for reduced SVD decompositions
 
     Returns
     -------
-    core_left: ndarray
+    core_left : np.ndarray
         TT core for first cell
-    core_right: ndarry
+    core_right : np.ndarry
         TT core for second cell
-    rank: int
+    rank : int
         TT rank
     """
 

--- a/scikit_tt/slim.py
+++ b/scikit_tt/slim.py
@@ -17,12 +17,12 @@ def slim_mme(state_space, single_cell_reactions, two_cell_reactions, threshold=0
 
     Parameters
     ----------
-    state_space : list of int
+    state_space : list[int]
         number of states of each cell in the NNIS
-    single_cell_reactions : list of lists of lists of ints and floats
+    single_cell_reactions :  list[list[list[int or float]]]
         list of considered single-cell reactions, i.e. single_cell_reactions[i][j] is a list of the form
         [reactant_state, product_state, reactions_rate] describing the jth reaction on the ith cell.
-    two_cell_reactions : list of lists of lists of ints and floats
+    two_cell_reactions : list[list[list[int or float]]]
         list of considered two-cell reactions, i.e. two_cell_reactions[i][j] is a list of the form
         [reactant_state_i, product_state_i, reactant_state_i+1, product_state_i+1, reactions_rate] describing the jth
         reaction between the ith and the (i+1)th cell.
@@ -181,12 +181,12 @@ def slim_mme_hom(state_space, single_cell_reactions, two_cell_reactions, cyclic=
 
     Parameters
     ----------
-    state_space : list of int
+    state_space : list[int]
         number of states of each cell in the NNIS
-    single_cell_reactions : list of lists of ints and floats
+    single_cell_reactions : list[list[int or float]]
         list of considered single-cell reactions, i.e. single_cell_reactions[i] is a list of the form
         [reactant_state, product_state, reactions_rate] describing the ith reaction on each cell.
-    two_cell_reactions : list of lists of ints and floats
+    two_cell_reactions : list[list[int or float]]
         list of considered two-cell reactions, i.e. two_cell_reactions[i] is a list of the form
         [reactant_state_i, product_state_i, reactant_state_i+1, product_state_i+1, reactions_rate] describing the ith
         reaction between neighboring cells

--- a/scikit_tt/solvers/evp.py
+++ b/scikit_tt/solvers/evp.py
@@ -10,35 +10,36 @@ from scikit_tt.tensor_train import TT
 
 
 def als(operator, initial_guess, operator_gevp=None, number_ev=1, repeats=1, solver='eig', sigma=1, real=True):
-    """Alternating linear scheme
+    """
+    Alternating linear scheme.
 
     Approximates eigenvalues and corresponding eigentensors of an (generalized) eigenvalue problem in the TT format.
     For details, see [1]_.
 
     Parameters
     ----------
-    operator: instance of TT class
+    operator : TT
         TT operator, left-hand side
-    initial_guess: instance of TT class
+    initial_guess : TT
         initial guess for the solution
-    operator_gevp: instance of TT class, optional
+    operator_gevp : TT, optional
         TT operator, right-hand side (for generalized eigenvalue problems), default is None
-    number_ev: int, optional
+    number_ev : int, optional
         number of eigenvalues and corresponding eigentensor to compute, default is 1
-    repeats: int, optional
+    repeats : int, optional
         number of repeats of the ALS, default is 1
-    solver: string, optional
+    solver : string, optional
         algorithm for obtaining the solutions of the micro systems, can be 'eig', 'eigs' or 'eigh', default is 'eig'
-    sigma: float, optional
+    sigma : float, optional
         find eigenvalues near sigma, default is 1
-    real: bool, optional
+    real : bool, optional
         whether to compute only real eigenvalues and eigentensors or not, default is True
 
     Returns
     -------
-    eigenvalues: float or list of floats
+    eigenvalues: float or list of float
         approximated eigenvalues, if number_ev>1 eigenvalues is a list of floats
-    eigentensors: instance of TT class or list of instances of TT class
+    eigentensors: TT or list of TT
         approximated eigentensors, if number_ev>1 eigentensors is a list of tensor trains
 
     References
@@ -132,29 +133,30 @@ def als(operator, initial_guess, operator_gevp=None, number_ev=1, repeats=1, sol
 
 
 def power_method(operator, initial_guess, operator_gevp=None, repeats=10, sigma=0.999):
-    """Inverse power iteration method
+    """
+    Inverse power iteration method.
 
     Approximates eigenvalues and corresponding eigentensors of an (generalized) eigenvalue problem in the TT format.
     For details, see [1]_.
 
     Parameters
     ----------
-    operator: instance of TT class
+    operator : TT
         TT operator, left-hand side
-    initial_guess: instance of TT class
+    initial_guess : TT
         initial guess for the solution
-    operator_gevp: instance of TT class, optional
+    operator_gevp : TT, optional
         TT operator, right-hand side (for generalized eigenvalue problems), default is None
-    repeats: int, optional
+    repeats : int, optional
         number of iterations, default is 10
-    sigma: float, optional
+    sigma : float, optional
         find eigenvalues near sigma, default is 1
 
     Returns
     -------
-    eigenvalue: float
+    eigenvalue : float
         approximated eigenvalue
-    eigentensor: instance of TT class
+    eigentensor : TT
         approximated eigentensors
 
     References
@@ -194,17 +196,18 @@ def power_method(operator, initial_guess, operator_gevp=None, repeats=10, sigma=
 
 
 def __construct_stack_left_op(i, stack_left_op, operator, solution):
-    """Construct left stack for left-hand side
+    """
+    Construct left stack for left-hand side.
 
     Parameters
     ----------
-    i: int
+    i : int
         core index
-    stack_left_op: list of ndarrays
+    stack_left_op : list of np.ndarray
         left stack for left-hand side
-    operator: instance of TT class
+    operator : TT
         TT operator of the system of linear equations
-    solution: instance of TT class
+    solution : TT
         approximated solution of the system of linear equations
     """
 
@@ -222,17 +225,18 @@ def __construct_stack_left_op(i, stack_left_op, operator, solution):
 
 
 def __construct_stack_right_op(i, stack_right_op, operator, solution):
-    """Construct right stack for left-hand side
+    """
+    Construct right stack for left-hand side.
 
     Parameters
     ----------
-    i: int
+    i : int
         core index
-    stack_right_op: list of ndarrays
+    stack_right_op : list of np.ndarray
         right stack for left-hand side
-    operator: instance of TT class
+    operator : TT
         TT operator side of the system of linear equations
-    solution: instance of TT class
+    solution : TT
         approximated solution of the system of linear equations
     """
 
@@ -250,24 +254,25 @@ def __construct_stack_right_op(i, stack_right_op, operator, solution):
 
 
 def __construct_micro_matrix_als(i, stack_left_op, stack_right_op, operator, solution):
-    """Construct micro matrix for ALS
+    """
+    Construct micro matrix for ALS.
 
     Parameters
     ----------
-    i: int
+    i : int
         core index
-    stack_left_op: list of ndarrays
+    stack_left_op : list of np.ndarray
         left stack for left-hand side
-    stack_right_op: list of ndarrays
+    stack_right_op : list of np.ndarray
         right stack for left-hand side
-    operator: instance of TT class
+    operator : TT
         TT operator of the system of linear equations
-    solution: instance of TT class
+    solution : TT
         approximated solution of the system of linear equations
 
     Returns
     -------
-    micro_op: ndarray
+    np.ndarray
         ith micro matrix
     """
 
@@ -283,23 +288,24 @@ def __construct_micro_matrix_als(i, stack_left_op, stack_right_op, operator, sol
 
 
 def __update_core_als(i, micro_op, micro_op_gevp, number_ev, solution, solver, sigma, real, direction):
-    """Update TT core for ALS
+    """
+    Update TT core for ALS.
 
     Parameters
     ----------
-    i: int
+    i : int
         core index
-    micro_op: ndarray
+    micro_op : np.ndarray
         micro matrix for ith TT core
-    solution: instance of TT class
+    solution : TT
         approximated solution of the eigenvalue problem
-    solver: string
+    solver : string
         algorithm for obtaining the solutions of the micro systems
-    sigma: float
+    sigma : float
         find eigenvalues near sigma
-    real: bool
+    real : bool
         whether to compute only real eigenvalues and eigentensors or not
-    direction: string
+    direction : string
         'forward' if first half sweep, 'backward' if second half sweep
     """
 

--- a/scikit_tt/solvers/evp.py
+++ b/scikit_tt/solvers/evp.py
@@ -37,9 +37,9 @@ def als(operator, initial_guess, operator_gevp=None, number_ev=1, repeats=1, sol
 
     Returns
     -------
-    eigenvalues: float or list of float
-        approximated eigenvalues, if number_ev>1 eigenvalues is a list of floats
-    eigentensors: TT or list of TT
+    eigenvalues: float or list[float]
+        approximated eigenvalues, if number_ev>1 eigenvalues is a list[float]
+    eigentensors: TT or list[TT]
         approximated eigentensors, if number_ev>1 eigentensors is a list of tensor trains
 
     References
@@ -203,7 +203,7 @@ def __construct_stack_left_op(i, stack_left_op, operator, solution):
     ----------
     i : int
         core index
-    stack_left_op : list of np.ndarray
+    stack_left_op : list[np.ndarray]
         left stack for left-hand side
     operator : TT
         TT operator of the system of linear equations
@@ -232,7 +232,7 @@ def __construct_stack_right_op(i, stack_right_op, operator, solution):
     ----------
     i : int
         core index
-    stack_right_op : list of np.ndarray
+    stack_right_op : list[np.ndarray]
         right stack for left-hand side
     operator : TT
         TT operator side of the system of linear equations
@@ -261,9 +261,9 @@ def __construct_micro_matrix_als(i, stack_left_op, stack_right_op, operator, sol
     ----------
     i : int
         core index
-    stack_left_op : list of np.ndarray
+    stack_left_op : list[np.ndarray]
         left stack for left-hand side
-    stack_right_op : list of np.ndarray
+    stack_right_op : list[np.ndarray]
         right stack for left-hand side
     operator : TT
         TT operator of the system of linear equations

--- a/scikit_tt/solvers/ode.py
+++ b/scikit_tt/solvers/ode.py
@@ -16,7 +16,7 @@ def explicit_euler(operator, initial_value, step_sizes, threshold=1e-12, max_ran
         TT operator of the differential equation
     initial_value : TT
         initial value of the differential equation
-    step_sizes : list of float
+    step_sizes : list[float]
         step sizes for the application of the implicit Euler method
     threshold : float, optional
         threshold for reduced SVD decompositions, default is 1e-12
@@ -29,7 +29,7 @@ def explicit_euler(operator, initial_value, step_sizes, threshold=1e-12, max_ran
 
     Returns
     -------
-    list of TT
+    list[TT]
         numerical solution of the differential equation
     """
 
@@ -71,14 +71,14 @@ def errors_expl_euler(operator, solution, step_sizes):
     ----------
     operator : TT
         TT operator of the differential equation
-    solution : list of TT
+    solution : list[TT]
         approximate solution of the linear differential equation
-    step_sizes : list of float
+    step_sizes : list[float]
         step sizes for the application of the implicit Euler method
 
     Returns
     -------
-    list of float
+    list[float]
         approximation errors
     """
 
@@ -105,7 +105,7 @@ def symmetric_euler(operator, initial_value, step_sizes, threshold=1e-12, max_ra
         TT operator of the differential equation
     initial_value : TT
         initial value of the differential equation
-    step_sizes : list of float
+    step_sizes : list[float]
         step sizes
     threshold : float, optional
         threshold for reduced SVD decompositions, default is 1e-12
@@ -118,7 +118,7 @@ def symmetric_euler(operator, initial_value, step_sizes, threshold=1e-12, max_ra
 
     Returns
     -------
-    list of TT
+    list[TT]
         numerical solution of the differential equation
 
     References
@@ -181,7 +181,7 @@ def implicit_euler(operator, initial_value, initial_guess, step_sizes, repeats=1
         initial value of the differential equation
     initial_guess : TT
         initial guess for the first step
-    step_sizes : list of float
+    step_sizes : list[float]
         step sizes for the application of the implicit Euler method
     repeats : int, optional
         number of repeats of the (M)ALS in each iteration step, default is 1
@@ -200,7 +200,7 @@ def implicit_euler(operator, initial_value, initial_guess, step_sizes, repeats=1
 
     Returns
     -------
-    list of TT
+    list[TT]
         numerical solution of the differential equation
     """
 
@@ -248,14 +248,14 @@ def errors_impl_euler(operator, solution, step_sizes):
     ----------
     operator : TT
         TT operator of the differential equation
-    solution : list of TT
+    solution : list[TT]
         approximate solution of the linear differential equation
-    step_sizes : list of float
+    step_sizes : list[float]
         step sizes for the application of the implicit Euler method
 
     Returns
     -------
-    list of float
+    list[float]
         approximation errors
     """
 
@@ -284,7 +284,7 @@ def trapezoidal_rule(operator, initial_value, initial_guess, step_sizes, repeats
         initial value of the differential equation
     initial_guess : TT
         initial guess for the first step
-    step_sizes : list of float
+    step_sizes : list[float]
         step sizes for the application of the trapezoidal rule
     repeats : int, optional
         number of repeats of the (M)ALS in each iteration step, default is 1
@@ -303,7 +303,7 @@ def trapezoidal_rule(operator, initial_value, initial_guess, step_sizes, repeats
 
     Returns
     -------
-    list of TT
+    list[TT]
         numerical solution of the differential equation
     """
 
@@ -353,14 +353,14 @@ def errors_trapezoidal(operator, solution, step_sizes):
     ----------
     operator : TT
         TT operator of the differential equation
-    solution : list of TT
+    solution : list[TT]
         approximate solution of the linear differential equation
-    step_sizes : list of float
+    step_sizes : list[float]
         step sizes for the application of the implicit Euler method
 
     Returns
     -------
-    list of float
+    list[float]
         approximation errors
     """
 
@@ -423,7 +423,7 @@ def adaptive_step_size(operator, initial_value, initial_guess, time_end, step_si
 
     Returns
     -------
-    list of TT
+    list[TT]
         numerical solution of the differential equation
     """
 

--- a/scikit_tt/solvers/ode.py
+++ b/scikit_tt/solvers/ode.py
@@ -1,4 +1,5 @@
 import scikit_tt.tensor_train as tt
+from scikit_tt.tensor_train import TT
 import scikit_tt.utils as utl
 from scikit_tt.solvers import sle
 import numpy as np
@@ -6,28 +7,29 @@ import time as _time
 
 
 def explicit_euler(operator, initial_value, step_sizes, threshold=1e-12, max_rank=50, normalize=1, progress=True):
-    """Explicit Euler method for linear differential equations in the TT format
+    """
+    Explicit Euler method for linear differential equations in the TT format.
 
     Parameters
     ----------
-    operator: instance of TT class
+    operator : TT
         TT operator of the differential equation
-    initial_value: instance of TT class
+    initial_value : TT
         initial value of the differential equation
-    step_sizes: list of floats
+    step_sizes : list of float
         step sizes for the application of the implicit Euler method
-    threshold: float, optional
+    threshold : float, optional
         threshold for reduced SVD decompositions, default is 1e-12
-    max_rank: int, optional
+    max_rank : int, optional
         maximum rank of the solution, default is 50
-    normalize: int (0, 1, or 2)
+    normalize : {0, 1, 2}, optional
         no normalization if 0, otherwise the solution is normalized in terms of Manhattan or Euclidean norm in each step
-    progress: bool, optional
+    progress : bool, optional
         whether to show the progress of the algorithm or not, default is True
 
     Returns
     -------
-    solution: list of instances of the TT class
+    list of TT
         numerical solution of the differential equation
     """
 
@@ -62,20 +64,21 @@ def explicit_euler(operator, initial_value, step_sizes, threshold=1e-12, max_ran
 
 
 def errors_expl_euler(operator, solution, step_sizes):
-    """Compute approximation errors of the explicit Euler method
+    """
+    Compute approximation errors of the explicit Euler method.
 
     Parameters
     ----------
-    operator: instance of TT class
+    operator : TT
         TT operator of the differential equation
-    solution: list of instances of TT class
+    solution : list of TT
         approximate solution of the linear differential equation
-    step_sizes: list of floats
+    step_sizes : list of float
         step sizes for the application of the implicit Euler method
 
     Returns
     -------
-    errors: list of floats
+    list of float
         approximation errors
     """
 
@@ -90,30 +93,32 @@ def errors_expl_euler(operator, solution, step_sizes):
 
     return errors
 
+
 def symmetric_euler(operator, initial_value, step_sizes, threshold=1e-12, max_rank=50, normalize=1, progress=True):
-    """Time-symmetrized explicit Euler ('second order differencing' in quantum mechanics) for linear differential 
+    """
+    Time-symmetrized explicit Euler ('second order differencing' in quantum mechanics) for linear differential
     equations in the TT format, see [1]_.
 
     Parameters
     ----------
-    operator: instance of TT class
+    operator : TT
         TT operator of the differential equation
-    initial_value: instance of TT class
+    initial_value : TT
         initial value of the differential equation
-    step_sizes: list of floats
+    step_sizes : list of float
         step sizes
-    threshold: float, optional
+    threshold : float, optional
         threshold for reduced SVD decompositions, default is 1e-12
-    max_rank: int, optional
+    max_rank : int, optional
         maximum rank of the solution, default is 50
-    normalize: int (0, 1, or 2)
+    normalize : {0, 1, 2}, optional
         no normalization if 0, otherwise the solution is normalized in terms of Manhattan or Euclidean norm in each step
-    progress: bool, optional
+    progress : bool, optional
         whether to show the progress of the algorithm or not, default is True
 
     Returns
     -------
-    solution: list of instances of the TT class
+    list of TT
         numerical solution of the differential equation
 
     References
@@ -165,36 +170,37 @@ def symmetric_euler(operator, initial_value, step_sizes, threshold=1e-12, max_ra
 
 def implicit_euler(operator, initial_value, initial_guess, step_sizes, repeats=1, tt_solver='als', threshold=1e-12,
                    max_rank=np.infty, micro_solver='solve', normalize=1, progress=True):
-    """Implicit Euler method for linear differential equations in the TT format
+    """
+    Implicit Euler method for linear differential equations in the TT format.
 
     Parameters
     ----------
-    operator: instance of TT class
+    operator : TT
         TT operator of the differential equation
-    initial_value: instance of TT class
+    initial_value : TT
         initial value of the differential equation
-    initial_guess: instance of TT class
+    initial_guess : TT
         initial guess for the first step
-    step_sizes: list of floats
+    step_sizes : list of float
         step sizes for the application of the implicit Euler method
-    repeats: int, optional
+    repeats : int, optional
         number of repeats of the (M)ALS in each iteration step, default is 1
-    tt_solver: string, optional
+    tt_solver : string, optional
         algorithm for solving the systems of linear equations in the TT format, default is 'als'
-    threshold: float, optional
+    threshold : float, optional
         threshold for reduced SVD decompositions, default is 1e-12
-    max_rank: int, optional
+    max_rank : int, optional
         maximum rank of the solution, default is infinity
-    micro_solver: string, optional
+    micro_solver : string, optional
         algorithm for obtaining the solutions of the micro systems, can be 'solve' or 'lu', default is 'solve'
-    normalize: int (0, 1, or 2)
+    normalize : {0, 1, 2}, optional
         no normalization if 0, otherwise the solution is normalized in terms of Manhattan or Euclidean norm in each step
-    progress: bool, optional
+    progress : bool, optional
         whether to show the progress of the algorithm or not, default is True
 
     Returns
     -------
-    solution: list of instances of the TT class
+    list of TT
         numerical solution of the differential equation
     """
 
@@ -235,20 +241,21 @@ def implicit_euler(operator, initial_value, initial_guess, step_sizes, repeats=1
 
 
 def errors_impl_euler(operator, solution, step_sizes):
-    """Compute approximation errors of the implicit Euler method
+    """
+    Compute approximation errors of the implicit Euler method.
 
     Parameters
     ----------
-    operator: instance of TT class
+    operator : TT
         TT operator of the differential equation
-    solution: list of instances of TT class
+    solution : list of TT
         approximate solution of the linear differential equation
-    step_sizes: list of floats
+    step_sizes : list of float
         step sizes for the application of the implicit Euler method
 
     Returns
     -------
-    errors: list of floats
+    list of float
         approximation errors
     """
 
@@ -266,36 +273,37 @@ def errors_impl_euler(operator, solution, step_sizes):
 
 def trapezoidal_rule(operator, initial_value, initial_guess, step_sizes, repeats=1, tt_solver='als', threshold=1e-12,
                      max_rank=np.infty, micro_solver='solve', normalize=1, progress=True):
-    """Trapezoidal rule for linear differential equations in the TT format
+    """
+    Trapezoidal rule for linear differential equations in the TT format.
 
     Parameters
     ----------
-    operator: instance of TT class
+    operator : TT
         TT operator of the differential equation
-    initial_value: instance of TT class
+    initial_value : TT
         initial value of the differential equation
-    initial_guess: instance of TT class
+    initial_guess : TT
         initial guess for the first step
-    step_sizes: list of floats
+    step_sizes : list of float
         step sizes for the application of the trapezoidal rule
-    repeats: int, optional
+    repeats : int, optional
         number of repeats of the (M)ALS in each iteration step, default is 1
-    tt_solver: string, optional
+    tt_solver : string, optional
         algorithm for solving the systems of linear equations in the TT format, default is 'als'
-    threshold: float, optional
+    threshold : float, optional
         threshold for reduced SVD decompositions, default is 1e-12
-    max_rank: int, optional
+    max_rank : int, optional
         maximum rank of the solution, default is infinity
-    micro_solver: string, optional
+    micro_solver : string, optional
         algorithm for obtaining the solutions of the micro systems, can be 'solve' or 'lu', default is 'solve'
-    normalize: int (0, 1, or 2)
+    normalize : {0, 1, 2}, optional
         no normalization if 0, otherwise the solution is normalized in terms of Manhattan or Euclidean norm in each step
-    progress: bool, optional
+    progress : bool, optional
         whether to show the progress of the algorithm or not, default is True
 
     Returns
     -------
-    solution: list of instances of the TT class
+    list of TT
         numerical solution of the differential equation
     """
 
@@ -338,20 +346,21 @@ def trapezoidal_rule(operator, initial_value, initial_guess, step_sizes, repeats
 
 
 def errors_trapezoidal(operator, solution, step_sizes):
-    """Compute approximation errors of the trapezoidal rule
+    """
+    Compute approximation errors of the trapezoidal rule.
 
     Parameters
     ----------
-    operator: instance of TT class
+    operator : TT
         TT operator of the differential equation
-    solution: list of instances of TT class
+    solution : list of TT
         approximate solution of the linear differential equation
-    step_sizes: list of floats
+    step_sizes : list of float
         step sizes for the application of the implicit Euler method
 
     Returns
     -------
-    errors: list of floats
+    list of float
         approximation errors
     """
 
@@ -371,49 +380,50 @@ def adaptive_step_size(operator, initial_value, initial_guess, time_end, step_si
                        solver='solve',
                        error_tol=1e-1, closeness_tol=0.5, step_size_min=1e-14, step_size_max=10, closeness_min=1e-3,
                        factor_max=2, factor_safe=0.9, second_method='two_step_Euler', normalize=1, progress=True):
-    """Adaptive step size method
+    """
+    Adaptive step size method.
 
     Parameters
     ----------
-    operator: instance of TT class
+    operator : TT
         TT operator of the differential equation
-    initial_value: instance of TT class
+    initial_value : TT
         initial value of the differential equation
-    initial_guess: instance of TT class
+    initial_guess : TT
         initial guess for the first step
-    time_end: float
+    time_end : float
         time point to which the ODE should be integrated
-    step_size_first: float, optional
+    step_size_first : float, optional
         first time step, default is 1e-10
-    repeats: int, optional
+    repeats : int, optional
         number of repeats of the ALS in each iteration step, default is 1
-    solver: string, optional
+    solver : string, optional
         algorithm for obtaining the solutions of the micro systems, can be 'solve' or 'lu', default is 'solve'
-    error_tol: float, optional
+    error_tol : float, optional
         tolerance for relative local error, default is 1e-1
-    closeness_tol: float, optional
+    closeness_tol : float, optional
         tolerance for relative change in the closeness to the stationary distribution, default is 0.5
-    step_size_min: float, optional
+    step_size_min : float, optional
         minimum step size, default is 1e-14
-    step_size_max: float, optional
+    step_size_max : float, optional
         maximum step size, default is 10
-    closeness_min: float, optional
+    closeness_min : float, optional
         minimum closeness value, default is 1e-3
-    factor_max: float, optional
+    factor_max : float, optional
         maximum factor for step size adaption, default is 2
-    factor_safe: float, optional
+    factor_safe : float, optional
         safety factor for step size adaption, default is 0.9
-    second_method: string, optional
+    second_method : {'two_step_Euler', 'trapezoidal_rule'}, optional
         which higher-order method should be used, can be 'two_step_Euler' or 'trapezoidal_rule', default is
         'two_step_Euler'
-    normalize: int (0, 1, or 2)
+    normalize : {0, 1, 2}, optional
         no normalization if 0, otherwise the solution is normalized in terms of Manhattan or Euclidean norm in each step
-    progress: bool, optional
+    progress : bool, optional
         whether to show the progress of the algorithm or not, default is True
 
     Returns
     -------
-    solution: list of instances of the TT class
+    list of TT
         numerical solution of the differential equation
     """
 

--- a/scikit_tt/solvers/sle.py
+++ b/scikit_tt/solvers/sle.py
@@ -186,7 +186,7 @@ def __construct_stack_left_op(i, stack_left_op, operator, solution):
     ----------
     i : int
         core index
-    stack_left_op : list of np.ndarray
+    stack_left_op : list[np.ndarray]
         left stack for left-hand side
     operator : TT
         TT operator of the system of linear equations
@@ -214,7 +214,7 @@ def __construct_stack_left_rhs(i, stack_left_rhs, right_hand_side, solution):
     ----------
     i : int
         core index
-    stack_left_rhs : list of np.ndarray
+    stack_left_rhs : list[np.ndarray]
         left stack for right-hand side
     right_hand_side : TT
         right-hand side of the system of linear equations
@@ -242,7 +242,7 @@ def __construct_stack_right_op(i, stack_right_op, operator, solution):
     ----------
     i : int
         core index
-    stack_right_op : list of np.ndarray
+    stack_right_op : list[np.ndarray]
         right stack for left-hand side
     operator : TT
         TT operator side of the system of linear equations
@@ -271,7 +271,7 @@ def __construct_stack_right_rhs(i, stack_right_rhs, right_hand_side, solution):
     ----------
     i : int
         core index
-    stack_right_rhs : list of np.ndarray
+    stack_right_rhs : list[np.ndarray]
         right stack for right-hand side
     right_hand_side : TT
         right-hand side of the system of linear equations
@@ -300,9 +300,9 @@ def __construct_micro_matrix_als(i, stack_left_op, stack_right_op, operator, sol
     ----------
     i : int
         core index
-    stack_left_op : list of np.ndarray
+    stack_left_op : list[np.ndarray]
         left stack for left-hand side
-    stack_right_op : list of np.ndarray
+    stack_right_op : list[np.ndarray]
         right stack for left-hand side
     operator : TT
         TT operator of the system of linear equations
@@ -335,9 +335,9 @@ def __construct_micro_matrix_mals(i, stack_left_op, stack_right_op, operator, so
     ----------
     i : int
         core index
-    stack_left_op : list of np.ndarray
+    stack_left_op : list[np.ndarray]
         left stack for left-hand side
-    stack_right_op : list of np.ndarray
+    stack_right_op : list[np.ndarray]
         right stack for left-hand side
     operator : TT
         TT operator of the system of linear equations
@@ -370,9 +370,9 @@ def __construct_micro_rhs_als(i, stack_left_rhs, stack_right_rhs, right_hand_sid
     ----------
     i : int
         core index
-    stack_left_rhs : list of np.ndarray
+    stack_left_rhs : list[np.ndarray]
         left stack for right-hand side
-    stack_right_rhs : list of np.ndarray
+    stack_right_rhs : list[np.ndarray]
         right stack for right-hand side
     right_hand_side : TT
         right-hand side of the system of linear equations
@@ -403,9 +403,9 @@ def __construct_micro_rhs_mals(i, stack_left_rhs, stack_right_rhs, right_hand_si
     ----------
     i : int
         core index
-    stack_left_rhs : list of np.ndarray
+    stack_left_rhs : list[np.ndarray]
         left stack for right-hand side
-    stack_right_rhs : list of np.ndarray
+    stack_right_rhs : list[np.ndarray]
         right stack for right-hand side
     right_hand_side : TT
         right-hand side of the system of linear equations

--- a/scikit_tt/solvers/sle.py
+++ b/scikit_tt/solvers/sle.py
@@ -3,29 +3,31 @@
 
 import numpy as np
 import scipy.linalg as lin
+from scikit_tt.tensor_train import TT
 
 
 def als(operator, initial_guess, right_hand_side, repeats=1, solver='solve'):
-    """Alternating linear scheme
+    """
+    Alternating linear scheme.
 
     Approximates the solution of a system of linear equations in the TT format. For details, see [1]_.
 
     Parameters
     ----------
-    operator: instance of TT class
+    operator : TT
         TT operator
-    initial_guess: instance of TT class
+    initial_guess : TT
         initial guess for the solution of operator @ x = right_hand_side
-    right_hand_side: instance of TT class
+    right_hand_side : TT
         right hand side of the system of linear equations
-    repeats: int, optional
+    repeats : int, optional
         number of repeats of the ALS, default is 1
-    solver: string, optional
+    solver : string, optional
         algorithm for obtaining the solutions of the micro systems, can be 'solve' or 'lu', default is 'solve'
 
     Returns
     -------
-    solution: instance of TT class
+    TT
         approximated solution of the system of linear equations
 
     References
@@ -89,30 +91,31 @@ def als(operator, initial_guess, right_hand_side, repeats=1, solver='solve'):
 
 
 def mals(operator, initial_guess, right_hand_side, repeats=1, solver='solve', threshold=1e-12, max_rank=np.infty):
-    """Modified alternating linear scheme for solving systems of linear equations in the TT format.
+    """
+    Modified alternating linear scheme for solving systems of linear equations in the TT format.
 
     Approximates the solution of a system of linear equations in the TT format. For details, see [1]_.
 
     Parameters
     ----------
-    operator: instance of TT class
+    operator : TT
         TT operator
-    initial_guess: instance of TT class
+    initial_guess : TT
         initial guess for the solution of operator @ x = right_hand_side
-    right_hand_side: instance of TT class
+    right_hand_side : TT
         right hand side of the system of linear equations
-    repeats: int, optional
+    repeats : int, optional
         number of repeats of the MALS, default is 1
-    solver: string, optional
+    solver : string, optional
         algorithm for obtaining the solutions of the micro systems, can be 'solve' or 'lu', default is 'solve'
-    threshold: float, optional
+    threshold : float, optional
         threshold for reduced SVD decompositions, default is 1e-12
-    max_rank: int, optional
+    max_rank : int, optional
         maximum rank of the solution, default is infinity
 
     Returns
     -------
-    solution: instance of TT class
+    TT
         approximated solution of the system of linear equations
 
     References
@@ -176,17 +179,18 @@ def mals(operator, initial_guess, right_hand_side, repeats=1, solver='solve', th
 
 
 def __construct_stack_left_op(i, stack_left_op, operator, solution):
-    """Construct left stack for left-hand side
+    """
+    Construct left stack for left-hand side.
 
     Parameters
     ----------
-    i: int
+    i : int
         core index
-    stack_left_op: list of ndarrays
+    stack_left_op : list of np.ndarray
         left stack for left-hand side
-    operator: instance of TT class
+    operator : TT
         TT operator of the system of linear equations
-    solution: instance of TT class
+    solution : TT
         approximated solution of the system of linear equations
     """
 
@@ -203,17 +207,18 @@ def __construct_stack_left_op(i, stack_left_op, operator, solution):
 
 
 def __construct_stack_left_rhs(i, stack_left_rhs, right_hand_side, solution):
-    """Construct left stack for right-hand side
+    """
+    Construct left stack for right-hand side.
 
     Parameters
     ----------
-    i: int
+    i : int
         core index
-    stack_left_rhs: list of ndarrays
+    stack_left_rhs : list of np.ndarray
         left stack for right-hand side
-    right_hand_side: instance of TT class
+    right_hand_side : TT
         right-hand side of the system of linear equations
-    solution: instance of TT class
+    solution : TT
         approximated solution of the system of linear equations
     """
 
@@ -230,17 +235,18 @@ def __construct_stack_left_rhs(i, stack_left_rhs, right_hand_side, solution):
 
 
 def __construct_stack_right_op(i, stack_right_op, operator, solution):
-    """Construct right stack for left-hand side
+    """
+    Construct right stack for left-hand side.
 
     Parameters
     ----------
-    i: int
+    i : int
         core index
-    stack_right_op: list of ndarrays
+    stack_right_op : list of np.ndarray
         right stack for left-hand side
-    operator: instance of TT class
+    operator : TT
         TT operator side of the system of linear equations
-    solution: instance of TT class
+    solution : TT
         approximated solution of the system of linear equations
     """
 
@@ -258,17 +264,18 @@ def __construct_stack_right_op(i, stack_right_op, operator, solution):
 
 
 def __construct_stack_right_rhs(i, stack_right_rhs, right_hand_side, solution):
-    """Construct right stack for right-hand side
+    """
+    Construct right stack for right-hand side.
 
     Parameters
     ----------
-    i: int
+    i : int
         core index
-    stack_right_rhs: list of ndarrays
+    stack_right_rhs : list of np.ndarray
         right stack for right-hand side
-    right_hand_side: instance of TT class
+    right_hand_side : TT
         right-hand side of the system of linear equations
-    solution: instance of TT class
+    solution : TT
         approximated solution of the system of linear equations
     """
 
@@ -286,24 +293,25 @@ def __construct_stack_right_rhs(i, stack_right_rhs, right_hand_side, solution):
 
 
 def __construct_micro_matrix_als(i, stack_left_op, stack_right_op, operator, solution):
-    """Construct micro matrix for ALS
+    """
+    Construct micro matrix for ALS.
 
     Parameters
     ----------
-    i: int
+    i : int
         core index
-    stack_left_op: list of ndarrays
+    stack_left_op : list of np.ndarray
         left stack for left-hand side
-    stack_right_op: list of ndarrays
+    stack_right_op : list of np.ndarray
         right stack for left-hand side
-    operator: instance of TT class
+    operator : TT
         TT operator of the system of linear equations
-    solution: instance of TT class
+    solution : TT
         approximated solution of the system of linear equations
 
     Returns
     -------
-    micro_op: ndarray
+    np.ndarray
         ith micro matrix
     """
 
@@ -320,24 +328,25 @@ def __construct_micro_matrix_als(i, stack_left_op, stack_right_op, operator, sol
 
 
 def __construct_micro_matrix_mals(i, stack_left_op, stack_right_op, operator, solution):
-    """Construct micro matrix for MALS
+    """
+    Construct micro matrix for MALS.
 
     Parameters
     ----------
-    i: int
+    i : int
         core index
-    stack_left_op: list of ndarrays
+    stack_left_op : list of np.ndarray
         left stack for left-hand side
-    stack_right_op: list of ndarrays
+    stack_right_op : list of np.ndarray
         right stack for left-hand side
-    operator: instance of TT class
+    operator : TT
         TT operator of the system of linear equations
-    solution: instance of TT class
+    solution : TT
         approximated solution of the system of linear equations
 
     Returns
     -------
-    micro_op: ndarray
+    np.ndarray
         ith micro matrix
     """
 
@@ -359,20 +368,20 @@ def __construct_micro_rhs_als(i, stack_left_rhs, stack_right_rhs, right_hand_sid
 
     Parameters
     ----------
-    i: int
+    i : int
         core index
-    stack_left_rhs: list of ndarrays
+    stack_left_rhs : list of np.ndarray
         left stack for right-hand side
-    stack_right_rhs: list of ndarrays
+    stack_right_rhs : list of np.ndarray
         right stack for right-hand side
-    right_hand_side: instance of TT class
+    right_hand_side : TT
         right-hand side of the system of linear equations
-    solution: instance of TT class
+    solution : TT
         approximated solution of the system of linear equations
 
     Returns
     -------
-    micro_rhs: ndarray
+    np.ndarray
         ith micro right-hand side
     """
 
@@ -387,24 +396,25 @@ def __construct_micro_rhs_als(i, stack_left_rhs, stack_right_rhs, right_hand_sid
 
 
 def __construct_micro_rhs_mals(i, stack_left_rhs, stack_right_rhs, right_hand_side, solution):
-    """Construct micro right-hand side for MALS
+    """
+    Construct micro right-hand side for MALS.
 
     Parameters
     ----------
-    i: int
+    i : int
         core index
-    stack_left_rhs: list of ndarrays
+    stack_left_rhs : list of np.ndarray
         left stack for right-hand side
-    stack_right_rhs: list of ndarrays
+    stack_right_rhs : list of np.ndarray
         right stack for right-hand side
-    right_hand_side: instance of TT class
+    right_hand_side : TT
         right-hand side of the system of linear equations
-    solution: instance of TT class
+    solution : TT
         approximated solution of the system of linear equations
 
     Returns
     -------
-    micro_rhs: ndarray
+    np.ndarray
         ith micro right-hand side
     """
 
@@ -421,21 +431,22 @@ def __construct_micro_rhs_mals(i, stack_left_rhs, stack_right_rhs, right_hand_si
 
 
 def __update_core_als(i, micro_op, micro_rhs, solution, solver, direction):
-    """Update TT core for ALS
+    """
+    Update TT core for ALS.
 
     Parameters
     ----------
-    i: int
+    i : int
         core index
-    micro_op: ndarray
+    micro_op : np.ndarray
         micro matrix for ith TT core
-    micro_rhs: ndarray
+    micro_rhs : np.ndarray
         micro right-hand side for ith TT core
-    solution: instance of TT class
+    solution : TT
         approximated solution of the system of linear equations
-    solver: string
+    solver : string
         algorithm for obtaining the solutions of the micro systems
-    direction: string
+    direction : string
         'forward' if first half sweep, 'backward' if second half sweep
     """
 
@@ -488,25 +499,26 @@ def __update_core_als(i, micro_op, micro_rhs, solution, solver, direction):
 
 
 def __update_core_mals(i, micro_op, micro_rhs, solution, solver, threshold, max_rank, direction):
-    """Update TT cores for MALS
+    """
+    Update TT cores for MALS.
 
     Parameters
     ----------
-    i: int
+    i : int
         core index
-    micro_op: ndarray
+    micro_op : np.ndarray
         micro matrix for ith and (i+1)th TT core
-    micro_rhs: ndarray
+    micro_rhs : np.ndarray
         micro right-hand side for ith and (i+1)th TT core
-    solution: instance of TT class
+    solution : TT
         approximated solution of the system of linear equations
-    solver: string
+    solver : string
         algorithm for obtaining the solutions of the micro systems
-    direction: string
+    direction : string
         'forward' if first half sweep, 'backward' if second half sweep
-    threshold: float
+    threshold : float
         threshold for reduced SVD decompositions
-    max_rank: int
+    max_rank : int
         maximum rank of the solution
     """
 

--- a/scikit_tt/tensor_train.py
+++ b/scikit_tt/tensor_train.py
@@ -35,13 +35,13 @@ class TT(object):
     ----------
     order : int
         order of the tensor train
-    row_dims : list of int
+    row_dims : list[int]
         list of the row dimensions of the tensor train
-    col_dims : list of int
+    col_dims : list[int]
         list of the column dimensions of the tensor train
-    ranks : list of int
+    ranks : list[int]
         list of the ranks of the tensor train
-    cores : list of np.ndarray
+    cores : list[np.ndarray]
         list of the cores of the tensor train
 
     Methods
@@ -117,8 +117,8 @@ class TT(object):
         """
         Parameters
         ----------
-        x : list of np.ndarray or np.ndarray
-            either a list of TT cores or a full tensor
+        x : list[np.ndarray] or np.ndarray
+            either a list[TT] cores or a full tensor
         threshold : float, optional
             threshold for reduced SVD decompositions, default is 0
         max_rank : int, optional
@@ -616,7 +616,7 @@ class TT(object):
 
         Parameters
         ----------
-        cores : list of int, optional
+        cores : list[int], optional
             cores which should be transposed, if cores=None (default), all cores are transposed
         conjugate : bool, optional
             whether to compute the conjugate transpose, default is False
@@ -784,7 +784,7 @@ class TT(object):
 
         Parameters
         ----------
-        indices : list of int
+        indices : list[int]
             indices of a single entry of self ([x_1, ..., x_d, y_1, ..., y_d])
 
         Returns
@@ -795,7 +795,7 @@ class TT(object):
         Raises
         ------
         TypeError
-            if indices is not a list of ints
+            if indices is not a list[int]
         ValueError
             if length of indices does not match the order of self
         IndexError
@@ -1227,9 +1227,9 @@ class TT(object):
 
         Parameters
         ----------
-        row_dims : list of list of int
+        row_dims : list[list[int]]
             row dimensions for the QTT representation
-        col_dims : list of list of int
+        col_dims : list[list[int]]
             col dimensions for the QTT representation
         threshold : float, optional
             threshold for reduced SVD decompositions, default is 0
@@ -1310,7 +1310,7 @@ class TT(object):
 
         Parameters
         ----------
-        merge_numbers : list of int
+        merge_numbers : list[int]
             list of core numbers for contractions
 
         Returns
@@ -1490,11 +1490,11 @@ def zeros(row_dims, col_dims, ranks=1):
 
     Parameters
     ----------
-    row_dims : list of int
+    row_dims : list[int]
         list of the row dimensions of the tensor train of all zeros
-    col_dims : list of int
+    col_dims : list[int]
         list of the column dimensions of the tensor train of all zeros
-    ranks : int or list of int, optional
+    ranks : int or list[int], optional
         list of the ranks of the tensor train of all zeros, default is [1, ..., 1]
 
     Returns
@@ -1522,11 +1522,11 @@ def ones(row_dims, col_dims, ranks=1):
 
     Parameters
     ----------
-    row_dims : list of int
+    row_dims : list[int]
         list of the row dimensions of the tensor train of all ones
-    col_dims : list of int
+    col_dims : list[int]
         list of the column dimensions of the tensor train of all ones
-    ranks : int or list of int, optional
+    ranks : int or list[int], optional
         list of the ranks of the tensor train of all ones, default is [1, ..., 1]
 
     Returns
@@ -1554,7 +1554,7 @@ def eye(dims):
 
     Parameters
     ----------
-    dims : list of int
+    dims : list[int]
         list of row/column dimensions of the identity tensor train
 
     Returns
@@ -1582,9 +1582,9 @@ def unit(dims, inds):
 
     Parameters
     ----------
-    dims : list of int
+    dims : list[int]
         dimensions of the tensor train
-    inds : list of int
+    inds : list[int]
         positions of the 1s
 
     Returns
@@ -1605,11 +1605,11 @@ def rand(row_dims, col_dims, ranks=1):
 
     Parameters
     ----------
-    row_dims : list of int
+    row_dims : list[int]
         list of row dimensions of the random tensor train
-    col_dims : list of int
+    col_dims : list[int]
         list of column dimensions of the random tensor train
-    ranks : int or list of int, optional
+    ranks : int or list[int], optional
         list of the ranks of the random tensor train, default is [1, ..., 1]
 
     Returns
@@ -1637,9 +1637,9 @@ def uniform(row_dims, ranks=1, norm=1):
 
     Parameters
     ----------
-    row_dims : list of int
+    row_dims : list[int]
         list of row dimensions of the random tensor train
-    ranks : int or list of int, optional
+    ranks : int or list[int], optional
         list of the ranks of the uniformly distributed tensor train, default is [1, ..., 1]
     norm : float, optional
         norm of the uniformly distributed tensor train, default is 1

--- a/scikit_tt/tensor_train.py
+++ b/scikit_tt/tensor_train.py
@@ -7,7 +7,8 @@ from scipy import linalg
 
 
 class TT(object):
-    """Tensor train class
+    """
+    Tensor train class
 
     Tensor trains [1]_ are defined in terms of different attributes. That is, a tensor train with order ``d`` is 
     given by a list of 4-dimensional tensors
@@ -32,15 +33,15 @@ class TT(object):
 
     Attributes
     ----------
-    order: int
+    order : int
         order of the tensor train
-    row_dims: list of ints
+    row_dims : list of int
         list of the row dimensions of the tensor train
-    col_dims: list of ints
+    col_dims : list of int
         list of the column dimensions of the tensor train
-    ranks: list of ints
+    ranks : list of int
         list of the ranks of the tensor train
-    cores: list of ndarrays
+    cores : list of np.ndarray
         list of the cores of the tensor train
 
     Methods
@@ -116,11 +117,11 @@ class TT(object):
         """
         Parameters
         ----------
-        x: list of ndarrays or ndarray
+        x : list of np.ndarray or np.ndarray
             either a list of TT cores or a full tensor
-        threshold: float, optional
+        threshold : float, optional
             threshold for reduced SVD decompositions, default is 0
-        max_rank: int, optional
+        max_rank : int, optional
             maximum rank of the left-orthonormalized tensor train, default is np.infty
 
         Raises
@@ -228,7 +229,8 @@ class TT(object):
             raise TypeError('Parameter must be either a list of cores or an ndarray.')
 
     def __repr__(self):
-        """String representation of tensor trains
+        """
+        String representation of tensor trains
 
         Print the attributes of a given tensor train.
         """
@@ -240,18 +242,19 @@ class TT(object):
                 '                  ranks    = {r}'.format(d=self.order, m=self.row_dims, n=self.col_dims, r=self.ranks))
 
     def __add__(self, tt_add):
-        """Sum of two tensor trains
+        """
+        Sum of two tensor trains.
 
         Add two given tensor trains with same row and column dimensions.
 
         Parameters
         ----------
-        tt_add: instance of TT class
+        tt_add : TT
             tensor train which is added to self
 
         Returns
         -------
-        tt_sum: instance of TT class
+        TT
             sum of tt_add and self
 
         Raises
@@ -303,18 +306,19 @@ class TT(object):
             raise TypeError('Unsupported parameter.')
 
     def __sub__(self, tt_sub):
-        """Difference of two tensor trains
+        """
+        Difference of two tensor trains.
 
         Subtract two given tensor trains.
 
         Parameters
         ----------
-        tt_sub: instance of TT class
+        tt_sub : TT
             tensor train which is subtracted from self
 
         Returns
         -------
-        tt_diff: instance of TT class
+        TT
             difference of tt_add and self
         """
 
@@ -324,16 +328,17 @@ class TT(object):
         return tt_diff
 
     def __mul__(self, scalar):
-        """Left-multiplication of tensor trains and scalars
+        """
+        Left-multiplication of tensor trains and scalars.
 
         Parameters
         ----------
-        scalar: int, float, or complex
+        scalar : int or float or complex
             scalar value for the left-multiplication
 
         Returns
         -------
-        tt_prod: instance of TT class
+        TT
             product of scalar and self
 
         Raises
@@ -357,16 +362,17 @@ class TT(object):
         return tt_prod
 
     def __rmul__(self, scalar):
-        """Right-multiplication of tensor trains and scalars
+        """
+        Right-multiplication of tensor trains and scalars.
 
         Parameters
         ----------
-        scalar: float
+        scalar : float
             scalar value for the right-multiplication
 
         Returns
         -------
-        tt_prod: instance of TT class
+        TT
             product of self and scalar
         """
 
@@ -376,19 +382,20 @@ class TT(object):
         return tt_prod
 
     def __matmul__(self, tt_mul):
-        """Multiplication of tensor trains
+        """
+        Multiplication of tensor trains.
 
         For Python 3.5 and higher, use the operator, i.e. T @ U = T.__matmul__(T,U). Otherwise you can use T.dot(U) or
         TT.dot(T,U).
 
         Parameters
         ----------
-        tt_mul: instance of TT class
+        tt_mul : TT
             tensor train which is multiplied with self
 
         Returns
         -------
-        tt_prod: instance of TT class or float
+        TT
             product of self and tt_mul
 
         Raises
@@ -425,18 +432,19 @@ class TT(object):
             raise TypeError('Unsupported argument.')
 
     def dot(self, tt_mul):
-        """Multiplication of tensor trains
+        """
+        Multiplication of tensor trains.
 
         Alias for TT.__matmul__().
 
         Parameters
         ----------
-        tt_mul: instance of TT class
+        tt_mul : TT
             tensor train which is multiplied with self
 
         Returns
         -------
-        tt_prod: instance of TT class or float
+        tt_prod : TT or float
             product of self and tt_mul
         """
 
@@ -446,25 +454,26 @@ class TT(object):
 
     def tensordot(self, other, num_axes, mode='last-first', overwrite=False):
         """
-        Computes index contraction between self and other. The axes for contraction have to be the last or the first
-        axes of self and other. Thus, there are 4 modes of operation: 'last-first', 'last-last', 'first-last' and
-        'first-first'. The sequence of not contracted cores of self is always maintained (cf. the 2nd example below).
+        Computes index contraction between self and other.
+
+        The axes for contraction have to be the last or the first axes of self and other. Thus, there are 4 modes of
+        operation: 'last-first', 'last-last', 'first-last' and 'first-first'. The sequence of not contracted cores of
+        self is always maintained (cf. the 2nd example below).
         For saving memory, you can choose to overwrite self with the tensordot.
 
         Parameters
         ----------
-        other: instance of TT class
-        num_axes: integer
+        other : TT
+        num_axes : int
             number of axes that should be contracted
-        mode: string
-            location of the axes for contraction on self-other; one of the following: 'last-first', 'last-last',
-            'first-last', 'first-first'
-        overwrite: bool
+        mode : {'last-first', 'last-last', 'first-last', 'first-first'}, optional
+            location of the axes for contraction on self-other
+        overwrite : bool, optional
             whether to overwrite self or not
             
         Returns
         -------
-        tdot: instance of TT class
+        TT
             tensordot(self, other)
 
         Examples
@@ -602,20 +611,21 @@ class TT(object):
         return tdot
 
     def transpose(self, cores=None, conjugate=False, overwrite=False):
-        """Transpose of tensor trains
+        """
+        Transpose of tensor trains.
 
         Parameters
         ----------
-        cores: list of ints, optional
+        cores : list of int, optional
             cores which should be transposed, if cores=None (default), all cores are transposed
-        conjugate: bool, optional
+        conjugate : bool, optional
             whether to compute the conjugate transpose, default is False
-        overwrite: bool, optional
+        overwrite : bool, optional
             whether to overwrite self or not, default is False
 
         Returns
         -------
-        tt_transpose: instance of TT class
+        TT
             transpose of self
 
         Examples
@@ -666,17 +676,19 @@ class TT(object):
 
     def rank_transpose(self, overwrite=False):
         """
-        Computes the rank-transposed of self, which has the same cores as self but in reversed order. To fit together,
+        Computes the rank-transposed of self.
+
+        The rank-transposed has the same cores as self but in reversed order. To fit together,
         every core needs to be transposed with respect to its ranks.
 
         Parameters
         ----------
-        overwrite: bool, optional
+        overwrite : bool, optional
             whether to overwrite self or not, default is False
 
         Returns
         -------
-        tt_transpose: instance of TT class
+        TT
             rank-transpose of self
 
         Examples
@@ -707,16 +719,17 @@ class TT(object):
         return tt_transpose
 
     def conj(self, overwrite=False):
-        """Complex conjugate of tensor trains
+        """
+        Complex conjugate of tensor trains.
 
         Parameters
         ----------
-        overwrite: bool, optional
+        overwrite : bool, optional
             whether to overwrite self or not, default is False
 
         Returns
         -------
-        tt_conj: instance of TT class
+        TT
             complex conjugate of self
         """
 
@@ -733,11 +746,12 @@ class TT(object):
         return tt_conj
 
     def isoperator(self):
-        """Operator check
+        """
+        Operator check.
 
         Returns
         -------
-        op_bool: boolean
+        bool
             true if self is a TT operator
         """
 
@@ -747,11 +761,12 @@ class TT(object):
         return op_bool
 
     def copy(self):
-        """Deep copy of tensor trains
+        """
+        Deep copy of tensor trains.
 
         Returns
         -------
-        tt_copy: instance of TT class
+        TT
             deep copy of self
         """
 
@@ -764,16 +779,17 @@ class TT(object):
         return tt_copy
 
     def element(self, indices):
-        """Single element of tensor trains
+        """
+        Single element of tensor trains.
 
         Parameters
         ----------
-        indices: list of ints
+        indices : list of int
             indices of a single entry of self ([x_1, ..., x_d, y_1, ..., y_d])
 
         Returns
         -------
-        entry: float
+        float
             single entry of self
 
         Raises
@@ -826,11 +842,12 @@ class TT(object):
             raise TypeError('Unsupported parameter.')
 
     def full(self):
-        """Conversion to full format
+        """
+        Conversion to full format.
 
         Returns
         -------
-        full_tensor : ndarray
+        full_tensor : np.ndarray
             full tensor representation of self (dimensions: m_1 x ... x m_d x n_1 x ... x n_d)
         """
 
@@ -855,13 +872,14 @@ class TT(object):
         return full_tensor
 
     def matricize(self):
-        """Matricization of tensor trains
+        """
+        Matricization of tensor trains.
 
         If self is a TT operator, then tt_mat is a matrix. Otherwise, the result is a vector.
 
         Returns
         -------
-        tt_mat: ndarray
+        np.ndarray
             matricization of self
         """
 
@@ -886,26 +904,27 @@ class TT(object):
 
     def ortho_left(self, start_index=0, end_index=None, threshold=0, max_rank=np.infty, progress=False,
                    string='Left-orthonormalization'):
-        """left-orthonormalization of tensor trains
+        """
+        left-orthonormalization of tensor trains.
 
         Parameters
         ----------
-        start_index: int, optional
+        start_index : int, optional
             start index for orthonormalization, default is 0
-        end_index: int, optional
+        end_index : int, optional
             end index for orthonormalization, default is the index of the penultimate core
-        threshold: float, optional
+        threshold : float, optional
             threshold for reduced SVD decompositions, default is 0
-        max_rank: int, optional
+        max_rank : int, optional
             maximum rank of the left-orthonormalized tensor train, default is np.infty
-        progress: boolean, optional
+        progress : bool, optional
             whether to show progress bar, default is False
-        string: string, optional
+        string : string, optional
             title of the progress bar if progress is True
 
         Returns
         -------
-        tt_ortho: instance of TT class
+        TT
             left-orthonormalized representation of self
 
         Raises
@@ -974,22 +993,23 @@ class TT(object):
             raise TypeError('Start and end indices must be integers.')
 
     def ortho_right(self, start_index=None, end_index=1, threshold=0, max_rank=np.infty):
-        """right-orthonormalization of tensor trains
+        """
+        right-orthonormalization of tensor trains.
 
         Parameters
         ----------
-        start_index: int, optional
+        start_index : int, optional
             start index for orthonormalization, default is the index of the last core
-        end_index: int, optional
+        end_index : int, optional
             end index for orthonormalization, default is 1
-        threshold: float, optional
+        threshold : float, optional
             threshold for reduced SVD decompositions, default is 0
-        max_rank: int, optional
+        max_rank : int, optional
             maximum rank of the left-orthonormalized tensor train, default is np.infty
 
         Returns
         -------
-        tt_ortho: instance of TT class
+        TT
             right-orthonormalized representation of self
 
         Raises
@@ -1054,18 +1074,19 @@ class TT(object):
             raise TypeError('Start and end indices must be integers.')
 
     def ortho(self, threshold=0, max_rank=np.infty):
-        """left- and right-orthonormalization of tensor trains
+        """
+        left- and right-orthonormalization of tensor trains.
 
         Parameters
         ----------
-        threshold: float, optional
+        threshold : float, optional
             threshold for reduced SVD decompositions, default is 0
-        max_rank: int
+        max_rank : int
             maximum rank of the right-orthonormalized tensor train
 
         Returns
         -------
-        tt_ortho: instance of TT class
+        TT
            right-orthonormalized representation of self
 
         Raises
@@ -1092,18 +1113,19 @@ class TT(object):
             raise ValueError('Threshold must be greater or equal 0.')
 
     def norm(self, p=2):
-        """Norm of tensor trains.
+        """
+        Norm of tensor trains.
 
         Counterpart of matrix and vector norms. This function is able to return four different norms of tensor trains.
 
         Parameters
         ----------
-        p: int
+        p : int
             order of the norm
 
         Returns
         -------
-        norm: float
+        float
             norm of self
 
         Notes
@@ -1189,7 +1211,8 @@ class TT(object):
             raise ValueError('p must be 1 or 2.')
 
     def tt2qtt(self, row_dims, col_dims, threshold=0):
-        """conversion from TT format into QTT format
+        """
+        conversion from TT format into QTT format.
 
         Split the TT cores of a given tensor train in order to obtain a QTT representation.
 
@@ -1204,16 +1227,16 @@ class TT(object):
 
         Parameters
         ----------
-        row_dims: list of lists of ints
+        row_dims : list of list of int
             row dimensions for the QTT representation
-        col_dims: list of lists of ints
+        col_dims : list of list of int
             col dimensions for the QTT representation
-        threshold: float, optional
+        threshold : float, optional
             threshold for reduced SVD decompositions, default is 0
 
         Returns
         -------
-        qtt_tensor: instance of TT class
+        TT
             QTT representation of self
         """
 
@@ -1271,7 +1294,8 @@ class TT(object):
         return qtt_tensor
 
     def qtt2tt(self, merge_numbers):
-        """conversion from QTT format into TT format
+        """
+        conversion from QTT format into TT format.
 
         Contract the QTT cores of a given quantized tensor train in order to obtain a TT representation.
 
@@ -1286,12 +1310,12 @@ class TT(object):
 
         Parameters
         ----------
-        merge_numbers: list of ints
+        merge_numbers : list of int
             list of core numbers for contractions
 
         Returns
         -------
-        tt_tensor: instance of TT class
+        TT
             TT representation of self
         """
 
@@ -1329,32 +1353,33 @@ class TT(object):
         return tt_tensor
 
     def svd(self, index, threshold=0, ortho_l=True, ortho_r=True, overwrite=False):
-        """Computation of a global SVD of a tensor train.
+        """
+        Computation of a global SVD of a tensor train.
 
         Construct a singular value decomposition of a (non-operator) tensor train t in the form of tensor networks u, s,
         and v such that, by contraction, t=u*diag(s)*v. See [1]_ and [2]_ for details.
 
         Parameters
         ----------
-        index: int
+        index : int
             the cores 0 to index-1 represent the row dimensions and index to order-1 the column dimensions of the
             unfolded version of self
-        threshold: float, optional
+        threshold : float, optional
             threshold for reduced SVD decompositions, default is 0
-        ortho_l: bool, optional
+        ortho_l : bool, optional
             whether to apply left-orthonormalization or not, default is True
-        ortho_r: bool, optional
+        ortho_r : bool, optional
             whether to apply right-orthonormalization or not, default is True
-        overwrite: bool, optional
+        overwrite : bool, optional
             whether to overwrite self or not, default is False
 
         Returns
         -------
-        u: instance of TT class
+        u : TT
             left-orthonormal part of the global SVD
-        s: ndarray
+        s : np.ndarray
             vector of singular values of the global SVD
-        v: instance of TT class
+        v : TT
             right-orthonormal part of the global SVD
 
         References
@@ -1406,28 +1431,29 @@ class TT(object):
         return u, s, v
 
     def pinv(self, index, threshold=0, ortho_l=True, ortho_r=True, overwrite=False):
-        """Computation of the pseudoinverse of a tensor train
+        """
+        Computation of the pseudoinverse of a tensor train.
 
         Construct the pseudoinverse of a (non-operator) tensor train by a global SVD. See [1]_, [2]_ and [3]_ for
         details.
 
         Parameters
         ----------
-        index: int
+        index : int
             the cores 0 to index-1 represent the row dimensions and index to order-1 the column dimensions of the
             unfolded version of self
-        threshold: float, optional
+        threshold : float, optional
             threshold for reduced SVD decompositions, default is 0
-        ortho_l: bool, optional
+        ortho_l : bool, optional
             whether to apply left-orthonormalization or not, default is True
-        ortho_r: bool, optional
+        ortho_r : bool, optional
             whether to apply right-orthonormalization or not, default is True
-        overwrite: bool, optional
+        overwrite : bool, optional
             whether to overwrite self or not, default is False
 
         Returns
         -------
-        p_inv: instance of TT class
+        TT
             pseudoinverse of a given tensor train
 
         References
@@ -1459,20 +1485,21 @@ class TT(object):
 # ----------------------------------------------------
 
 def zeros(row_dims, col_dims, ranks=1):
-    """tensor train of all zeros
+    """
+    tensor train of all zeros.
 
     Parameters
     ----------
-    row_dims: list of ints
+    row_dims : list of int
         list of the row dimensions of the tensor train of all zeros
-    col_dims: list of ints
+    col_dims : list of int
         list of the column dimensions of the tensor train of all zeros
-    ranks: int or list of ints, optional
+    ranks : int or list of int, optional
         list of the ranks of the tensor train of all zeros, default is [1, ..., 1]
 
     Returns
     -------
-    tt_zeros: instance of TT class
+    TT
         tensor train of all zeros
     """
 
@@ -1490,20 +1517,21 @@ def zeros(row_dims, col_dims, ranks=1):
 
 
 def ones(row_dims, col_dims, ranks=1):
-    """tensor train of all ones
+    """
+    tensor train of all ones.
 
     Parameters
     ----------
-    row_dims: list of ints
+    row_dims : list of int
         list of the row dimensions of the tensor train of all ones
-    col_dims: list of ints
+    col_dims : list of int
         list of the column dimensions of the tensor train of all ones
-    ranks: int or list of ints, optional
+    ranks : int or list of int, optional
         list of the ranks of the tensor train of all ones, default is [1, ..., 1]
 
     Returns
     -------
-    tt_ones: instance of TT class
+    TT
         tensor train of all ones
     """
 
@@ -1521,16 +1549,17 @@ def ones(row_dims, col_dims, ranks=1):
 
 
 def eye(dims):
-    """identity tensor train
+    """
+    identity tensor train.
 
     Parameters
     ----------
-    dims: list of ints
+    dims : list of int
         list of row/column dimensions of the identity tensor train
 
     Returns
     -------
-    tt_eye: instance of TT class
+    TT
         identity tensor train
     """
 
@@ -1546,20 +1575,21 @@ def eye(dims):
 
 
 def unit(dims, inds):
-    """Canonical unit tensor
+    """
+    Canonical unit tensor.
 
     Return specific canonical unit tensor in given dimensions.
 
     Parameters
     ----------
-    dims: list of ints
+    dims : list of int
         dimensions of the tensor train
-    inds: list of ints
+    inds : list of int
         positions of the 1s
 
     Returns
     -------
-    t: instance of TT class
+    TT
         unit tensor train
     """
 
@@ -1570,20 +1600,21 @@ def unit(dims, inds):
 
 
 def rand(row_dims, col_dims, ranks=1):
-    """random tensor train
+    """
+    random tensor train.
 
     Parameters
     ----------
-    row_dims: list of ints
+    row_dims : list of int
         list of row dimensions of the random tensor train
-    col_dims: list of ints
+    col_dims : list of int
         list of column dimensions of the random tensor train
-    ranks: int or list of ints, optional
+    ranks : int or list of int, optional
         list of the ranks of the random tensor train, default is [1, ..., 1]
 
     Returns
     -------
-    tt_rand: instance of TT class
+    TT
         random tensor train
     """
 
@@ -1601,20 +1632,21 @@ def rand(row_dims, col_dims, ranks=1):
 
 
 def uniform(row_dims, ranks=1, norm=1):
-    """uniformly distributed tensor train
+    """
+    uniformly distributed tensor train.
 
     Parameters
     ----------
-    row_dims: list of ints
+    row_dims : list of int
         list of row dimensions of the random tensor train
-    ranks: int or list of ints, optional
+    ranks : int or list of int, optional
         list of the ranks of the uniformly distributed tensor train, default is [1, ..., 1]
-    norm: float, optional
+    norm : float, optional
         norm of the uniformly distributed tensor train, default is 1
 
     Returns
     -------
-    tt_uni: instance of TT class
+    TT
         uniformly distributed tensor train
     """
 

--- a/scikit_tt/utils.py
+++ b/scikit_tt/utils.py
@@ -7,13 +7,14 @@ import time
 
 
 def header(title=None, subtitle=None):
-    """Print scikit_tt header
+    """
+    Print scikit_tt header.
 
     Parameters
     ----------
-    title: string
+    title : string
         title or name of the procedure
-    subtitle: string
+    subtitle : string
         subtitle of the procedure
     """
 
@@ -32,21 +33,22 @@ def header(title=None, subtitle=None):
 
 
 def progress(str_text, percent, cpu_time=0, show=True, width=47):
-    """Show progress in percent
+    """
+    Show progress in percent.
 
     Print strings of the form, e.g., 'Running ... 10%' etc., without line breaks.
 
     Parameters
     ----------
-    str_text: string
+    str_text : string
         string to print
-    percent: float
+    percent : float
         current progress; if percent=0, the current time is returned
-    cpu_time: float
+    cpu_time : float
         current CPU time
-    show: bool, optional
+    show : bool, optional
         whether to print the progress, default is True
-    width: int
+    width : int
         width of the progress bar, default is 47
     """
 
@@ -89,7 +91,8 @@ def progress(str_text, percent, cpu_time=0, show=True, width=47):
 
 
 class timer(object):
-    """Measure CPU time
+    """
+    Measure CPU time.
 
     Can be executed using the 'with' statement in order to measure the CPU time needed for calculations.
     """


### PR DESCRIPTION
I adapted all the docstrings in scikit_tt/scikit_tt to the numpy docstring standard.
The most important changes are 'instance of TT class' to 'TT' and 'ndarray' to 'np.ndarray'.  This enables IDEs like Pycharm to recognize the type of output of a function as TT, which enables it to suggest code.
For example:
T_tt = scikit_tt.tensor_train.rand([2, 3, 4], [5, 6, 7], ranks=3)
If I now type 'T_tt.' Pycharm can provide an overview of all the TT class methods, like matricize or ortho.

This massively improves the workflow with scikit_tt as you dont have to jump into the TT class file to  manually search for the method you need.

None of the semantics of the docstrings were changed.