### PR TITLE
Restrict Numpy version <2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy >= 1.18.0; python_version >= '3.5'
+numpy >= 1.18.0,<2.0; python_version >= '3.5'
 numpy == 1.16.4; python_version == '2.7'
 
 scipy >= 1.0.1; python_version >= '3.5'


### PR DESCRIPTION
# Situation
Currently, Scikit-tt can't be run as-is after pulling the repo, since it uses np.infty, which was removed in numpy 2.0. 
At least on my machine the requirements get evaluated to use numpy>=2.0.

# Solution
Fixing the numpy version is very easy to do manually but I figure it might be nicer to have it in the requirements and done automatically.